### PR TITLE
Add line-level review marker backend (REST API + JDBC storage)

### DIFF
--- a/Documentation/config-accounts.txt
+++ b/Documentation/config-accounts.txt
@@ -485,6 +485,23 @@ multiple primary servers handling write operations where reviewed flags should
 be replicated between the primary nodes one could implement a store for the
 reviewed flags that is based on MySQL with replication.
 
+[[line-reviewed-flags]]
+=== Line/Region Reviewed Flags
+
+In addition to file-level reviewed flags, reviewers can mark individual
+lines or character ranges within a file as reviewed. These line-level
+(and region-level) reviewed flags are stored in a separate database table
+`account_patch_line_reviews`. The table holds: account ID, change ID,
+patch set ID, file path, line number (1-based), side (PARENT/REVISION),
+and optional range (start_line, start_char, end_line, end_char), matching
+the attributes used for comments.
+
+By default the same database as file-level reviewed flags is used (see
+`accountPatchReviewDb`). To use a different database, set
+`accountPatchLineReviewDb.url` in `gerrit.config`. Plugins can provide
+an alternate implementation by implementing
+`AccountPatchLineReviewStore`.
+
 [[account-sequence]]
 == Account Sequence
 

--- a/Documentation/dev-line-reviewed-flags-verification.md
+++ b/Documentation/dev-line-reviewed-flags-verification.md
@@ -16,8 +16,15 @@ bazel test //javatests/com/google/gerrit/acceptance/api/revision:RevisionIT --te
 # Run account deletion test (clears both file and line reviewed flags)
 bazel test //javatests/com/google/gerrit/acceptance/api/accounts:api_account --test_filter=".*deleteAccount.*Reviewed.*"
 
-# Run line-level reviewed flags acceptance test (regex: method names containing LineReviewed)
+# Run line-level reviewed flags store test (store-level mark/find/clear)
 bazel test //javatests/com/google/gerrit/acceptance/api/revision:RevisionIT --test_filter=".*LineReviewed.*"
+
+# Run HTTP-level acceptance tests for reviewed_lines REST endpoints
+# (PUT/GET/DELETE success and error cases)
+bazel test //javatests/com/google/gerrit/acceptance/api/revision:RevisionIT --test_filter=".*[Rr]eviewedLines.*"
+
+# Run JDBC unit tests (exercises real SQL against an in-memory H2 database)
+bazel test //javatests/com/google/gerrit/server:server_tests --test_filter=JdbcAccountPatchLineReviewStoreTest
 ```
 
 ## 2. Manual verification via REST API
@@ -144,6 +151,14 @@ After marking a line or region, query the table and confirm a row exists for the
 - **Cleanup:** Line-level flags are cleared when: the change is deleted, the account is deleted, the patch set is deleted (consistency checker), or (when configured) changes are abandoned. Confirm this matches your expectations.
 - **UI:** The current change only adds backend storage and REST API. Polygerrit (or another UI) would need to call these endpoints and show line/region reviewed state; that is separate work.
 
-## 5. Optional: add an acceptance test
+## 5. Test coverage summary
 
-An acceptance test can create a change, mark a line as reviewed via REST with a body, then assert via the store or GET that the flag is present, and clear it and assert it’s gone. See `RevisionIT.setUnsetReviewedFlag` for the file-level pattern; the line-level test would use `restSession.put(uri, lineReviewedInput)` and `restSession.get(uri)` for `.../reviewed_lines`.
+The following tests cover the line-level reviewed flags feature:
+
+| Test | What it covers |
+|---|---|
+| `JdbcAccountPatchLineReviewStoreTest` | Real SQL: INSERT, SELECT, DELETE; idempotency; isolation by account/patchset/file; range storage; `clearLineReviewed(PatchSet.Id)`, `clearLineReviewed(Change.Id)`, `clearLineReviewedBy(Account.Id)` |
+| `RevisionIT#setUnsetLineReviewedFlag` | Store-level mark + find + clear via injected store |
+| `RevisionIT#putReviewedLines_*` / `getReviewedLines_*` / `deleteReviewedLines_*` | Full HTTP round-trip: PUT (new → 201, repeat → 200), GET (empty list, single line, with range, PARENT side), error cases (line=0 → 400, missing body → 400), DELETE without body → 400 |
+| `ChangesRestApiBindingsIT#revisionFileEndpoints` | Route binding: GET/PUT/DELETE `.../reviewed_lines` are registered and reachable |
+| `AccountIT#deleteAccount_deletesReviewedFlags` (file-level only) | Verifies that deleting an account clears file-level reviewed flags; the same code path clears line-level flags via `clearLineReviewedBy` |

--- a/Documentation/dev-line-reviewed-flags-verification.md
+++ b/Documentation/dev-line-reviewed-flags-verification.md
@@ -1,0 +1,149 @@
+# Verifying Line/Region Review Flags
+
+This guide describes how to verify that the line-level and region-level reviewed flags implementation is correct and matches your expectations.
+
+## 1. Run existing tests
+
+Ensure you don’t break current behavior and that new code is exercised:
+
+```bash
+# Run REST API binding tests (includes GET/PUT/DELETE .../reviewed_lines)
+bazel test //javatests/com/google/gerrit/acceptance/rest/binding:rest_bindings
+
+# Run file-level reviewed-flag tests (regex: method names containing Reviewed)
+bazel test //javatests/com/google/gerrit/acceptance/api/revision:RevisionIT --test_filter=".*Reviewed.*"
+
+# Run account deletion test (clears both file and line reviewed flags)
+bazel test //javatests/com/google/gerrit/acceptance/api/accounts:api_account --test_filter=".*deleteAccount.*Reviewed.*"
+
+# Run line-level reviewed flags acceptance test (regex: method names containing LineReviewed)
+bazel test //javatests/com/google/gerrit/acceptance/api/revision:RevisionIT --test_filter=".*LineReviewed.*"
+```
+
+## 2. Manual verification via REST API
+
+Use `curl` (or any HTTP client) against a running Gerrit instance. Replace `GERRIT_URL`, `CHANGE_ID`, `REVISION`, `FILE_PATH`, and use an auth cookie or `-u user:http-password` as needed.
+
+**How to test the PUT (mark line reviewed):**
+
+1. **Start Gerrit**.
+
+2. **Get a change that has at least one file.** If you have no projects/repos yet, do the following once:
+
+   **a) Create a project** (pick one):
+
+   - **REST:**  
+     `curl -X PUT -u user:http_password -H "Content-Type: application/json" -d '{"create_empty_commit":true}' "http://localhost:8080/a/projects/demo"`
+   - **SSH:**  
+     `ssh -p 29418 user@localhost gerrit create-project --branch master --empty-commit demo`  
+     (adjust port/host if your Gerrit uses different SSH settings.)
+
+   **b) Clone the project and push a commit** (so the change has a real file):
+
+   ```bash
+   git clone http://localhost:8080/demo demo && cd demo
+   # Optional: install commit-msg hook so commits get a Change-Id (see Gerrit docs)
+   echo "hello" > readme.txt
+   git add readme.txt && git commit -m "Add readme"
+   git push origin HEAD:refs/for/master
+   ```
+
+   The push output will show the change number (e.g. `remote: (NEW) abc123 refs/changes/12/42/1` → change **42**). Use that number and the file name (e.g. `readme.txt`) in the curl below.
+
+   If you already have a project and change, use any existing change number and a file path from that change.
+
+3. **From your change, note:**
+   - **CHANGE_ID**: change number or `I...` id (e.g. `42` or `Iabc123...`).
+   - **REVISION**: use `current` for the latest patch set, or the commit SHA (e.g. `1` or `abc123...`).
+   - **FILE_PATH**: a file in that patch (e.g. `readme.txt` or `foo/bar.txt`). For URL safety, encode slashes as `%2F` (e.g. `foo%2Fbar.txt`).
+
+4. **Authenticate.** You must be logged in. Either:
+   - **HTTP password:** `curl -u USER:HTTP_PASSWORD ...` (get the password from Gerrit: Profile → HTTP Password).
+   - **Cookie:** log in in the browser, then use `curl ... -b 'cookie_name=cookie_value'` (inspect your browser cookies for the Gerrit host).
+
+5. **Run the PUT** with real values (example: line 10, file `foo/bar.txt`, change 42, current revision):
+
+   ```bash
+   curl -X PUT \
+     -u youruser:your_http_password \
+     -H "Content-Type: application/json" \
+     -d '{"line": 10}' \
+     "http://localhost:8080/a/changes/42/revisions/current/files/foo%2Fbar.txt/reviewed_lines"
+   ```
+
+   Expect **200 OK** or **201 Created**.
+
+6. **Verify with GET** (same URL without `-X PUT` and without `-d`):
+
+   ```bash
+   curl -u youruser:your_http_password \
+     "http://localhost:8080/a/changes/42/revisions/current/files/foo%2Fbar.txt/reviewed_lines"
+   ```
+
+   Expect **200 OK** and a JSON array containing the reviewed line, e.g. `[{"line":10,"side":"REVISION"}]`.
+
+**Mark line 10 as reviewed (current revision side):**
+
+```bash
+curl -X PUT \
+  -H "Content-Type: application/json" \
+  -d '{"line": 10}' \
+  "https://GERRIT_URL/a/changes/CHANGE_ID/revisions/REVISION/files/FILE_PATH/reviewed_lines"
+```
+
+**Mark a region (e.g. lines 10–15):**
+
+```bash
+curl -X PUT \
+  -H "Content-Type: application/json" \
+  -d '{
+    "line": 10,
+    "range": {
+      "startLine": 10,
+      "startCharacter": 0,
+      "endLine": 15,
+      "endCharacter": 0
+    },
+    "side": "REVISION"
+  }' \
+  "https://GERRIT_URL/a/changes/CHANGE_ID/revisions/REVISION/files/FILE_PATH/reviewed_lines"
+```
+
+**List reviewed lines for the file:**
+
+```bash
+curl "https://GERRIT_URL/a/changes/CHANGE_ID/revisions/REVISION/files/FILE_PATH/reviewed_lines"
+```
+
+**Clear a line/region (same body as when marking):**
+
+```bash
+curl -X DELETE \
+  -H "Content-Type: application/json" \
+  -d '{"line": 10}' \
+  "https://GERRIT_URL/a/changes/CHANGE_ID/revisions/REVISION/files/FILE_PATH/reviewed_lines"
+```
+
+Expect: `PUT` returns 200/201, `GET` returns 200 with a JSON array of `LineReviewedInfo`, `DELETE` returns 204.
+
+## 3. Database verification
+
+If using the default H2 or another JDBC store, confirm the table and data:
+
+- **Table:** `account_patch_line_reviews`
+- **Columns:** `account_id`, `change_id`, `patch_set_id`, `file_name`, `line_number`, `side`, `start_line`, `start_char`, `end_line`, `end_char`
+- **Primary key:** `(change_id, patch_set_id, account_id, file_name, line_number, side, start_line, start_char, end_line, end_char)`
+
+After marking a line or region, query the table and confirm a row exists for the expected user, change, patch set, file, line/range, and side.
+
+## 4. Checklist: is this what you want?
+
+- **Attributes:** Line/region flags use the same concepts as comments: 1-based `line`, optional `range` (start/end line and character), and `side` (PARENT vs REVISION). If you need different semantics, the API and store can be adjusted.
+- **Storage:** Flags are stored in a dedicated table and can use the same DB as file-level flags (`accountPatchReviewDb`) or a separate one (`accountPatchLineReviewDb.url`). Confirm config and DB choice.
+- **REST:** Endpoints are under the file resource: `GET/PUT/DELETE .../files/{path}/reviewed_lines`. PUT/DELETE require a JSON body with at least `line` (and optionally `range`, `side`). If you prefer a different URL shape or body format, that can be changed.
+- **Cleanup:** Line-level flags are cleared when: the change is deleted, the account is deleted, the patch set is deleted (consistency checker), or (when configured) changes are abandoned. Confirm this matches your expectations.
+- **UI:** The current change only adds backend storage and REST API. Polygerrit (or another UI) would need to call these endpoints and show line/region reviewed state; that is separate work.
+
+## 5. Optional: add an acceptance test
+
+An acceptance test can create a change, mark a line as reviewed via REST with a body, then assert via the store or GET that the flag is present, and clear it and assert it’s gone. See `RevisionIT.setUnsetReviewedFlag` for the file-level pattern; the line-level test would use `restSession.put(uri, lineReviewedInput)` and `restSession.get(uri)` for `.../reviewed_lines`.

--- a/java/com/google/gerrit/acceptance/GerritServer.java
+++ b/java/com/google/gerrit/acceptance/GerritServer.java
@@ -71,6 +71,7 @@ import com.google.gerrit.server.ssh.NoSshModule;
 import com.google.gerrit.server.util.ReplicaUtil;
 import com.google.gerrit.server.util.SocketUtil;
 import com.google.gerrit.server.util.SystemLog;
+import com.google.gerrit.testing.FakeAccountPatchLineReviewStore;
 import com.google.gerrit.testing.FakeAccountPatchReviewStore.FakeAccountPatchReviewStoreModule;
 import com.google.gerrit.testing.FakeEmailSender.FakeEmailSenderModule;
 import com.google.gerrit.testing.GitRepositoryCountingManagerModule;
@@ -431,6 +432,8 @@ public class GerritServer implements AutoCloseable {
               }
             },
             site);
+    daemon.setAccountPatchLineReviewStoreModuleForTesting(
+        new FakeAccountPatchLineReviewStore.FakeAccountPatchLineReviewStoreModule());
     daemon.setAccountPatchReviewStoreModuleForTesting(new FakeAccountPatchReviewStoreModule());
     daemon.setEmailModuleForTesting(new FakeEmailSenderModule());
     daemon.setAuditEventModuleForTesting(

--- a/java/com/google/gerrit/extensions/api/changes/LineReviewedInput.java
+++ b/java/com/google/gerrit/extensions/api/changes/LineReviewedInput.java
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+import com.google.gerrit.extensions.client.Comment.Range;
+import com.google.gerrit.extensions.client.Side;
+
+/**
+ * Input for marking a line or region as reviewed.
+ *
+ * <p>Attributes mirror those used for comments: line (1-based), optional range for region-level,
+ * and side (PARENT vs REVISION).
+ */
+public class LineReviewedInput {
+  /** Line number (1-based). Required. */
+  public Integer line;
+
+  /** Optional range for region-level review. If null, only the line is marked reviewed. */
+  public Range range;
+
+  /** Side of the diff: PARENT (0) or REVISION (1). Default is REVISION. */
+  public Side side;
+}

--- a/java/com/google/gerrit/extensions/common/LineReviewedInfo.java
+++ b/java/com/google/gerrit/extensions/common/LineReviewedInfo.java
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import com.google.gerrit.extensions.client.Comment.Range;
+import com.google.gerrit.extensions.client.Side;
+
+/**
+ * Information about a line or region that has been marked as reviewed.
+ *
+ * <p>Attributes mirror those used for comments: line number (1-based), optional range for
+ * region-level, and side (PARENT vs REVISION).
+ */
+public class LineReviewedInfo {
+  /** Line number (1-based). For a region, this is typically the start line. */
+  public Integer line;
+
+  /** Optional range for region-level review. If null, only the line is marked reviewed. */
+  public Range range;
+
+  /** Side of the diff: PARENT (0) or REVISION (1). Default is REVISION. */
+  public Side side;
+}

--- a/java/com/google/gerrit/httpd/init/WebAppInitializer.java
+++ b/java/com/google/gerrit/httpd/init/WebAppInitializer.java
@@ -102,6 +102,7 @@ import com.google.gerrit.server.plugins.PluginGuiceEnvironment;
 import com.google.gerrit.server.plugins.PluginModule;
 import com.google.gerrit.server.project.DefaultLockManager.DefaultLockManagerModule;
 import com.google.gerrit.server.restapi.RestApiModule;
+import com.google.gerrit.server.schema.JdbcAccountPatchLineReviewStore.JdbcAccountPatchLineReviewStoreModule;
 import com.google.gerrit.server.schema.JdbcAccountPatchReviewStore.JdbcAccountPatchReviewStoreModule;
 import com.google.gerrit.server.schema.NoteDbSchemaVersionCheck;
 import com.google.gerrit.server.schema.SchemaModule;
@@ -310,6 +311,7 @@ public class WebAppInitializer extends GuiceServletContextListener implements Fi
     modules.add(new DropWizardMetricMaker.RestModule());
     modules.add(new LogFileManagerModule());
     modules.add(new EventBrokerModule());
+    modules.add(new JdbcAccountPatchLineReviewStoreModule(config));
     modules.add(new JdbcAccountPatchReviewStoreModule(config));
     modules.add(cfgInjector.getInstance(GitRepositoryManagerModule.class));
     modules.add(new StreamEventsApiListenerModule(config));

--- a/java/com/google/gerrit/pgm/Daemon.java
+++ b/java/com/google/gerrit/pgm/Daemon.java
@@ -121,6 +121,7 @@ import com.google.gerrit.server.plugins.PluginGuiceEnvironment;
 import com.google.gerrit.server.plugins.PluginModule;
 import com.google.gerrit.server.project.DefaultLockManager.DefaultLockManagerModule;
 import com.google.gerrit.server.restapi.RestApiModule;
+import com.google.gerrit.server.schema.JdbcAccountPatchLineReviewStore.JdbcAccountPatchLineReviewStoreModule;
 import com.google.gerrit.server.schema.JdbcAccountPatchReviewStore.JdbcAccountPatchReviewStoreModule;
 import com.google.gerrit.server.schema.NoteDbSchemaVersionCheck;
 import com.google.gerrit.server.securestore.DefaultSecureStore;
@@ -233,6 +234,7 @@ public class Daemon extends SiteProgram {
   private Path runFile;
   private boolean inMemoryTest;
   private AbstractModule indexModule;
+  private Module accountPatchLineReviewStoreModule;
   private Module accountPatchReviewStoreModule;
   private Module emailModule;
   private List<Module> testSysModules = new ArrayList<>();
@@ -365,6 +367,11 @@ public class Daemon extends SiteProgram {
   }
 
   @VisibleForTesting
+  public void setAccountPatchLineReviewStoreModuleForTesting(Module module) {
+    accountPatchLineReviewStoreModule = module;
+  }
+
+  @VisibleForTesting
   public void setAccountPatchReviewStoreModuleForTesting(Module module) {
     accountPatchReviewStoreModule = module;
   }
@@ -487,6 +494,11 @@ public class Daemon extends SiteProgram {
     modules.add(new WorkQueueModule());
     modules.add(new StreamEventsApiListenerModule(config));
     modules.add(new EventBrokerModule());
+    if (accountPatchLineReviewStoreModule != null) {
+      modules.add(accountPatchLineReviewStoreModule);
+    } else {
+      modules.add(new JdbcAccountPatchLineReviewStoreModule(config));
+    }
     if (accountPatchReviewStoreModule != null) {
       modules.add(accountPatchReviewStoreModule);
     } else {

--- a/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
@@ -1,0 +1,163 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.change;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.gerrit.entities.Account;
+import com.google.gerrit.entities.Change;
+import com.google.gerrit.entities.PatchSet;
+import com.google.gerrit.extensions.api.changes.LineReviewedInput;
+import com.google.gerrit.extensions.client.Comment.Range;
+import com.google.gerrit.extensions.client.Side;
+import com.google.gerrit.extensions.restapi.NotImplementedException;
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Store for line-level and region-level reviewed flags on changes.
+ *
+ * <p>A line/region reviewed flag records that a user has reviewed a specific line or character
+ * range within a file in a patch set. Attributes mirror comments: file path, line number (1-based),
+ * optional range (startLine, startChar, endLine, endChar), and side (PARENT/REVISION).
+ *
+ * <p>For cluster setups with multiple primary nodes the store must replicate the data between the
+ * primary servers.
+ */
+public interface AccountPatchLineReviewStore {
+
+  /** Describes a single reviewed line or region within a file. */
+  @AutoValue
+  abstract class ReviewedLine {
+    public abstract String path();
+
+    /** 1-based line number. */
+    public abstract int lineNumber();
+
+    /** Side: 0 = PARENT, 1 = REVISION. */
+    public abstract short side();
+
+    /** Range (startLine, startChar, endLine, endChar). For line-only, startLine==endLine==lineNumber. */
+    public abstract int startLine();
+
+    public abstract int startChar();
+
+    public abstract int endLine();
+
+    public abstract int endChar();
+
+    public static ReviewedLine create(
+        String path,
+        int lineNumber,
+        short side,
+        int startLine,
+        int startChar,
+        int endLine,
+        int endChar) {
+      return new AutoValue_AccountPatchLineReviewStore_ReviewedLine(
+          path, lineNumber, side, startLine, startChar, endLine, endChar);
+    }
+
+    public Side getSide() {
+      Side s = Side.fromShort(side());
+      return s != null ? s : Side.REVISION;
+    }
+  }
+
+  /** Patch set with the list of reviewed lines/regions for a user. */
+  @AutoValue
+  abstract class PatchSetWithReviewedLines {
+    public abstract PatchSet.Id patchSetId();
+
+    public abstract ImmutableList<ReviewedLine> lines();
+
+    public static PatchSetWithReviewedLines create(PatchSet.Id id, ImmutableList<ReviewedLine> lines) {
+      return new AutoValue_AccountPatchLineReviewStore_PatchSetWithReviewedLines(id, lines);
+    }
+  }
+
+  /**
+   * Marks the given line or region in the given file and patch set as reviewed by the given user.
+   *
+   * @param psId patch set ID
+   * @param accountId account ID of the user
+   * @param path file path
+   * @param input line number, optional range, and side
+   * @return {@code true} if the flag was updated, {@code false} if it was already set
+   */
+  boolean markLineReviewed(
+      PatchSet.Id psId, Account.Id accountId, String path, LineReviewedInput input);
+
+  /**
+   * Marks the given lines/regions as reviewed by the given user.
+   *
+   * @param psId patch set ID
+   * @param accountId account ID of the user
+   * @param path file path
+   * @param inputs list of line/region inputs
+   */
+  void markLineReviewed(
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      Collection<LineReviewedInput> inputs);
+
+  /**
+   * Clears the reviewed flag for the given line/region.
+   *
+   * @param psId patch set ID
+   * @param accountId account ID of the user
+   * @param path file path
+   * @param input line number, optional range, and side (must match the stored entry)
+   */
+  void clearLineReviewed(
+      PatchSet.Id psId, Account.Id accountId, String path, LineReviewedInput input);
+
+  /**
+   * Clears all line/region reviewed flags for the given patch set for all users.
+   *
+   * @param psId patch set ID
+   */
+  void clearLineReviewed(PatchSet.Id psId);
+
+  /**
+   * Clears all line/region reviewed flags for all patch sets in the given change for all users.
+   *
+   * @param changeId change ID
+   */
+  void clearLineReviewed(Change.Id changeId);
+
+  /**
+   * Clears all line/region reviewed flags for the given user.
+   *
+   * @param accountId account ID of the user
+   */
+  default void clearLineReviewedBy(Account.Id accountId) {
+    throw new NotImplementedException(
+        "clearLineReviewedBy() is not implemented for this AccountPatchLineReviewStore.");
+  }
+
+  /**
+   * Finds all reviewed lines/regions for the given patch set and user (for the given file, or all
+   * files if path is null).
+   *
+   * @param psId patch set ID
+   * @param accountId account ID of the user
+   * @param path optional file path to filter by, or null for all files
+   * @return list of reviewed lines/regions
+   */
+  Optional<PatchSetWithReviewedLines> findReviewedLines(
+      PatchSet.Id psId, Account.Id accountId, String path);
+}

--- a/java/com/google/gerrit/server/change/BatchAbandon.java
+++ b/java/com/google/gerrit/server/change/BatchAbandon.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 public class BatchAbandon {
   private final AbandonOp.Factory abandonOpFactory;
   private final ChangeCleanupConfig cfg;
+  private final PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore;
   private final PluginItemContext<AccountPatchReviewStore> accountPatchReviewStore;
   private final StoreSubmitRequirementsOp.Factory storeSubmitRequirementsOpFactory;
 
@@ -44,10 +45,12 @@ public class BatchAbandon {
   BatchAbandon(
       AbandonOp.Factory abandonOpFactory,
       ChangeCleanupConfig cfg,
+      PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore,
       PluginItemContext<AccountPatchReviewStore> accountPatchReviewStore,
       StoreSubmitRequirementsOp.Factory storeSubmitRequirementsOpFactory) {
     this.abandonOpFactory = abandonOpFactory;
     this.cfg = cfg;
+    this.accountPatchLineReviewStore = accountPatchLineReviewStore;
     this.accountPatchReviewStore = accountPatchReviewStore;
     this.storeSubmitRequirementsOpFactory = storeSubmitRequirementsOpFactory;
   }
@@ -91,6 +94,7 @@ public class BatchAbandon {
 
         if (cfg.getCleanupAccountPatchReview()) {
           cleanupAccountPatchReview(changes);
+          cleanupAccountPatchLineReview(changes);
         }
       }
     }
@@ -118,6 +122,12 @@ public class BatchAbandon {
   private void cleanupAccountPatchReview(Collection<ChangeData> changes) {
     for (ChangeData change : changes) {
       accountPatchReviewStore.run(s -> s.clearReviewed(change.getId()));
+    }
+  }
+
+  private void cleanupAccountPatchLineReview(Collection<ChangeData> changes) {
+    for (ChangeData change : changes) {
+      accountPatchLineReviewStore.run(s -> s.clearLineReviewed(change.getId()));
     }
   }
 }

--- a/java/com/google/gerrit/server/change/ConsistencyChecker.java
+++ b/java/com/google/gerrit/server/change/ConsistencyChecker.java
@@ -109,6 +109,7 @@ public class ConsistencyChecker {
 
   private final ChangeNotes.Factory notesFactory;
   private final Accounts accounts;
+  private final PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore;
   private final PluginItemContext<AccountPatchReviewStore> accountPatchReviewStore;
   private final GitRepositoryManager repoManager;
   private final PatchSetInfoFactory patchSetInfoFactory;
@@ -138,6 +139,7 @@ public class ConsistencyChecker {
       @GerritPersonIdent Provider<PersonIdent> serverIdent,
       ChangeNotes.Factory notesFactory,
       Accounts accounts,
+      PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore,
       PluginItemContext<AccountPatchReviewStore> accountPatchReviewStore,
       GitRepositoryManager repoManager,
       PatchSetInfoFactory patchSetInfoFactory,
@@ -147,6 +149,7 @@ public class ConsistencyChecker {
       RetryHelper retryHelper,
       ChangeUtil changeUtil) {
     this.accounts = accounts;
+    this.accountPatchLineReviewStore = accountPatchLineReviewStore;
     this.accountPatchReviewStore = accountPatchReviewStore;
     this.notesFactory = notesFactory;
     this.patchSetInfoFactory = patchSetInfoFactory;
@@ -702,6 +705,7 @@ public class ConsistencyChecker {
     @Override
     public boolean updateChange(ChangeContext ctx) throws PatchSetInfoNotAvailableException {
       // Delete dangling key references.
+      accountPatchLineReviewStore.run(s -> s.clearLineReviewed(psId));
       accountPatchReviewStore.run(s -> s.clearReviewed(psId));
 
       // For NoteDb setting the state to deleted is sufficient to filter everything out.

--- a/java/com/google/gerrit/server/change/DeleteChangeOp.java
+++ b/java/com/google/gerrit/server/change/DeleteChangeOp.java
@@ -48,6 +48,7 @@ public class DeleteChangeOp implements BatchUpdateOp {
 
   private final PatchSetUtil psUtil;
   private final StarredChangesWriter starredChangesWriter;
+  private final PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore;
   private final PluginItemContext<AccountPatchReviewStore> accountPatchReviewStore;
   private final ChangeData.Factory changeDataFactory;
   private final ChangeDeleted changeDeleted;
@@ -57,12 +58,14 @@ public class DeleteChangeOp implements BatchUpdateOp {
   DeleteChangeOp(
       PatchSetUtil psUtil,
       StarredChangesWriter starredChangesWriter,
+      PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore,
       PluginItemContext<AccountPatchReviewStore> accountPatchReviewStore,
       ChangeData.Factory changeDataFactory,
       ChangeDeleted changeDeleted,
       @Assisted Change.Id id) {
     this.psUtil = psUtil;
     this.starredChangesWriter = starredChangesWriter;
+    this.accountPatchLineReviewStore = accountPatchLineReviewStore;
     this.accountPatchReviewStore = accountPatchReviewStore;
     this.changeDataFactory = changeDataFactory;
     this.changeDeleted = changeDeleted;
@@ -122,6 +125,7 @@ public class DeleteChangeOp implements BatchUpdateOp {
   }
 
   private void cleanUpReferences(ChangeData cd) throws IOException {
+    accountPatchLineReviewStore.run(s -> s.clearLineReviewed(cd.getId()));
     accountPatchReviewStore.run(s -> s.clearReviewed(cd.virtualId()));
 
     // Non-atomic operation on All-Users refs; not much we can do to make it atomic.

--- a/java/com/google/gerrit/server/config/GerritGlobalModule.java
+++ b/java/com/google/gerrit/server/config/GerritGlobalModule.java
@@ -120,6 +120,7 @@ import com.google.gerrit.server.avatar.AvatarProvider;
 import com.google.gerrit.server.cache.CacheDef;
 import com.google.gerrit.server.cache.CacheRemovalListener;
 import com.google.gerrit.server.change.AbandonOp;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore;
 import com.google.gerrit.server.change.AccountPatchReviewStore;
 import com.google.gerrit.server.change.ChangeFinder;
 import com.google.gerrit.server.change.ChangeJson;
@@ -462,6 +463,7 @@ public class GerritGlobalModule extends FactoryModule {
     DynamicItem.itemOf(binder(), OAuthTokenEncrypter.class);
     DynamicSet.setOf(binder(), AccountExternalIdCreator.class);
     DynamicSet.setOf(binder(), WebUiPlugin.class);
+    DynamicItem.itemOf(binder(), AccountPatchLineReviewStore.class);
     DynamicItem.itemOf(binder(), AccountPatchReviewStore.class);
     DynamicSet.setOf(binder(), ActionVisitor.class);
     DynamicItem.itemOf(binder(), MergeSuperSetComputation.class);

--- a/java/com/google/gerrit/server/restapi/account/DeleteAccount.java
+++ b/java/com/google/gerrit/server/restapi/account/DeleteAccount.java
@@ -43,6 +43,7 @@ import com.google.gerrit.server.account.AccountSshKey;
 import com.google.gerrit.server.account.AccountsUpdate;
 import com.google.gerrit.server.account.AuthTokenAccessor;
 import com.google.gerrit.server.account.VersionedAuthorizedKeys;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore;
 import com.google.gerrit.server.change.AccountPatchReviewStore;
 import com.google.gerrit.server.config.AccountConfig;
 import com.google.gerrit.server.edit.ChangeEdit;
@@ -90,6 +91,7 @@ public class DeleteAccount implements RestModifyView<AccountResource, Input> {
   private final GitRepositoryManager gitManager;
   private final Provider<InternalChangeQuery> queryProvider;
   private final ChangeEditUtil changeEditUtil;
+  private final PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore;
   private final PluginItemContext<AccountPatchReviewStore> accountPatchReviewStore;
   private final PublicKeyStoreUtil publicKeyStoreUtil;
   private final AccountConfig accountConfig;
@@ -110,6 +112,7 @@ public class DeleteAccount implements RestModifyView<AccountResource, Input> {
       GitRepositoryManager gitManager,
       Provider<InternalChangeQuery> queryProvider,
       ChangeEditUtil changeEditUtil,
+      PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore,
       PluginItemContext<AccountPatchReviewStore> accountPatchReviewStore,
       PublicKeyStoreUtil publicKeyStoreUtil,
       AccountConfig accountConfig,
@@ -125,6 +128,7 @@ public class DeleteAccount implements RestModifyView<AccountResource, Input> {
     this.gitManager = gitManager;
     this.queryProvider = queryProvider;
     this.changeEditUtil = changeEditUtil;
+    this.accountPatchLineReviewStore = accountPatchLineReviewStore;
     this.accountPatchReviewStore = accountPatchReviewStore;
     this.publicKeyStoreUtil = publicKeyStoreUtil;
     this.accountConfig = accountConfig;
@@ -152,6 +156,7 @@ public class DeleteAccount implements RestModifyView<AccountResource, Input> {
       deleteChangeEdits(userId);
       tokenAccessor.deleteAllTokens(user.getAccountId());
       deleteDraftCommentsUtil.deleteDraftComments(user, null);
+      accountPatchLineReviewStore.run(a -> a.clearLineReviewedBy(userId));
       accountPatchReviewStore.run(a -> a.clearReviewedBy(userId));
       removeUserFromGroups(user);
       accountsUpdateProvider

--- a/java/com/google/gerrit/server/restapi/change/ChangeRestApiModule.java
+++ b/java/com/google/gerrit/server/restapi/change/ChangeRestApiModule.java
@@ -31,6 +31,7 @@ import com.google.gerrit.extensions.registration.DynamicMap;
 import com.google.gerrit.extensions.restapi.RestApiModule;
 import com.google.gerrit.server.restapi.change.Reviewed.DeleteReviewed;
 import com.google.gerrit.server.restapi.change.Reviewed.PutReviewed;
+import com.google.gerrit.server.restapi.change.ReviewedLines;
 
 public class ChangeRestApiModule extends RestApiModule {
   @Override
@@ -157,6 +158,9 @@ public class ChangeRestApiModule extends RestApiModule {
     get(FILE_KIND, "download").to(DownloadContent.class);
     put(FILE_KIND, "reviewed").to(PutReviewed.class);
     delete(FILE_KIND, "reviewed").to(DeleteReviewed.class);
+    get(FILE_KIND, "reviewed_lines").to(ReviewedLines.GetReviewedLines.class);
+    put(FILE_KIND, "reviewed_lines").to(ReviewedLines.PutReviewedLine.class);
+    delete(FILE_KIND, "reviewed_lines").to(ReviewedLines.DeleteReviewedLine.class);
 
     child(REVISION_KIND, "fixes").to(Fixes.class);
     post(FIX_KIND, "apply").to(ApplyStoredFix.class);

--- a/java/com/google/gerrit/server/restapi/change/ReviewedLines.java
+++ b/java/com/google/gerrit/server/restapi/change/ReviewedLines.java
@@ -1,0 +1,140 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.restapi.change;
+
+import com.google.gerrit.extensions.common.LineReviewedInfo;
+import com.google.gerrit.extensions.restapi.BadRequestException;
+import com.google.gerrit.extensions.restapi.Response;
+import com.google.gerrit.extensions.restapi.RestModifyView;
+import com.google.gerrit.extensions.restapi.RestReadView;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore;
+import com.google.gerrit.server.change.FileResource;
+import com.google.gerrit.server.plugincontext.PluginItemContext;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/** REST API for line-level and region-level reviewed flags within a file. */
+public class ReviewedLines {
+
+  @Singleton
+  public static class GetReviewedLines implements RestReadView<FileResource> {
+    private final PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore;
+
+    @Inject
+    GetReviewedLines(
+        PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore) {
+      this.accountPatchLineReviewStore = accountPatchLineReviewStore;
+    }
+
+    @Override
+    public Response<List<LineReviewedInfo>> apply(FileResource resource) {
+      Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> result =
+          accountPatchLineReviewStore.call(
+              s ->
+                  s.findReviewedLines(
+                      resource.getPatchKey().patchSetId(),
+                      resource.getAccountId(),
+                      resource.getPatchKey().fileName()));
+
+      List<LineReviewedInfo> infos = new ArrayList<>();
+      result.ifPresent(
+          patchSetWithReviewedLines -> {
+            for (AccountPatchLineReviewStore.ReviewedLine line :
+                patchSetWithReviewedLines.lines()) {
+              LineReviewedInfo info = new LineReviewedInfo();
+              info.line = line.lineNumber();
+              info.side = line.getSide();
+              if (line.startLine() != line.endLine()
+                  || line.startChar() != 0
+                  || line.endChar() != 0) {
+                info.range = new com.google.gerrit.extensions.client.Comment.Range();
+                info.range.startLine = line.startLine();
+                info.range.startCharacter = line.startChar();
+                info.range.endLine = line.endLine();
+                info.range.endCharacter = line.endChar();
+              }
+              infos.add(info);
+            }
+          });
+      return Response.ok(infos);
+    }
+  }
+
+  @Singleton
+  public static class PutReviewedLine
+      implements RestModifyView<FileResource, com.google.gerrit.extensions.api.changes.LineReviewedInput> {
+    private final PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore;
+
+    @Inject
+    PutReviewedLine(
+        PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore) {
+      this.accountPatchLineReviewStore = accountPatchLineReviewStore;
+    }
+
+    @Override
+    public Response<String> apply(
+        FileResource resource,
+        com.google.gerrit.extensions.api.changes.LineReviewedInput input)
+        throws BadRequestException {
+      if (input == null || input.line == null || input.line < 1) {
+        throw new BadRequestException("line is required (1-based)");
+      }
+      boolean updated =
+          accountPatchLineReviewStore.call(
+              s ->
+                  s.markLineReviewed(
+                      resource.getPatchKey().patchSetId(),
+                      resource.getAccountId(),
+                      resource.getPatchKey().fileName(),
+                      input));
+      return updated ? Response.created() : Response.ok();
+    }
+  }
+
+  @Singleton
+  public static class DeleteReviewedLine
+      implements RestModifyView<FileResource, com.google.gerrit.extensions.api.changes.LineReviewedInput> {
+    private final PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore;
+
+    @Inject
+    DeleteReviewedLine(
+        PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore) {
+      this.accountPatchLineReviewStore = accountPatchLineReviewStore;
+    }
+
+    @Override
+    public Response<?> apply(
+        FileResource resource,
+        com.google.gerrit.extensions.api.changes.LineReviewedInput input)
+        throws BadRequestException {
+      if (input == null || input.line == null || input.line < 1) {
+        throw new BadRequestException("line is required (1-based)");
+      }
+      accountPatchLineReviewStore.run(
+          s ->
+              s.clearLineReviewed(
+                  resource.getPatchKey().patchSetId(),
+                  resource.getAccountId(),
+                  resource.getPatchKey().fileName(),
+                  input));
+      return Response.none();
+    }
+  }
+
+  private ReviewedLines() {}
+}

--- a/java/com/google/gerrit/server/schema/CloudSpannerAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/CloudSpannerAccountPatchLineReviewStore.java
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.schema;
+
+import com.google.gerrit.exceptions.DuplicateKeyException;
+import com.google.gerrit.exceptions.StorageException;
+import com.google.gerrit.server.config.GerritServerConfig;
+import com.google.gerrit.server.config.SitePaths;
+import com.google.gerrit.server.config.ThreadSettingsConfig;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.eclipse.jgit.lib.Config;
+
+@Singleton
+public class CloudSpannerAccountPatchLineReviewStore extends JdbcAccountPatchLineReviewStore {
+
+  private static final int ERR_DUP_KEY = 6;
+
+  @Inject
+  CloudSpannerAccountPatchLineReviewStore(
+      @GerritServerConfig Config cfg,
+      SitePaths sitePaths,
+      ThreadSettingsConfig threadSettingsConfig) {
+    super(cfg, sitePaths, threadSettingsConfig);
+  }
+
+  @Override
+  public StorageException convertError(String op, SQLException err) {
+    return switch (err.getErrorCode()) {
+      case ERR_DUP_KEY -> new DuplicateKeyException("ACCOUNT_PATCH_LINE_REVIEWS", err);
+      default -> new StorageException(op + " failure on ACCOUNT_PATCH_LINE_REVIEWS", err);
+    };
+  }
+
+  @Override
+  protected void doCreateTable(Statement stmt) throws SQLException {
+    stmt.executeUpdate(
+        "CREATE TABLE IF NOT EXISTS account_patch_line_reviews ("
+            + "account_id INT64 NOT NULL DEFAULT (0),"
+            + "change_id INT64 NOT NULL DEFAULT (0),"
+            + "patch_set_id INT64 NOT NULL DEFAULT (0),"
+            + "file_name STRING(MAX) NOT NULL DEFAULT (''),"
+            + "line_number INT64 NOT NULL DEFAULT (1),"
+            + "side INT64 NOT NULL DEFAULT (1),"
+            + "start_line INT64 NOT NULL DEFAULT (1),"
+            + "start_char INT64 NOT NULL DEFAULT (0),"
+            + "end_line INT64 NOT NULL DEFAULT (1),"
+            + "end_char INT64 NOT NULL DEFAULT (0)"
+            + ") PRIMARY KEY(change_id, patch_set_id, account_id, file_name, line_number, side, "
+            + "start_line, start_char, end_line, end_char)");
+  }
+}

--- a/java/com/google/gerrit/server/schema/H2AccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/H2AccountPatchLineReviewStore.java
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.schema;
+
+import com.google.gerrit.exceptions.DuplicateKeyException;
+import com.google.gerrit.exceptions.StorageException;
+import com.google.gerrit.server.config.GerritServerConfig;
+import com.google.gerrit.server.config.SitePaths;
+import com.google.gerrit.server.config.ThreadSettingsConfig;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.sql.SQLException;
+import org.eclipse.jgit.lib.Config;
+
+@Singleton
+public class H2AccountPatchLineReviewStore extends JdbcAccountPatchLineReviewStore {
+
+  @Inject
+  H2AccountPatchLineReviewStore(
+      @GerritServerConfig Config cfg,
+      SitePaths sitePaths,
+      ThreadSettingsConfig threadSettingsConfig) {
+    super(cfg, sitePaths, threadSettingsConfig);
+  }
+
+  @Override
+  public StorageException convertError(String op, SQLException err) {
+    switch (getSQLStateInt(err)) {
+      case 23001, 23505 -> {
+        return new DuplicateKeyException("account_patch_line_reviews", err);
+      }
+      default -> {
+        if (err.getCause() == null && err.getNextException() != null) {
+          err.initCause(err.getNextException());
+        }
+        return new StorageException(op + " failure on account_patch_line_reviews", err);
+      }
+    }
+  }
+}

--- a/java/com/google/gerrit/server/schema/H2AccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/H2AccountPatchLineReviewStore.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.server.schema;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gerrit.exceptions.DuplicateKeyException;
 import com.google.gerrit.exceptions.StorageException;
 import com.google.gerrit.server.config.GerritServerConfig;
@@ -22,6 +23,7 @@ import com.google.gerrit.server.config.ThreadSettingsConfig;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.sql.SQLException;
+import javax.sql.DataSource;
 import org.eclipse.jgit.lib.Config;
 
 @Singleton
@@ -33,6 +35,11 @@ public class H2AccountPatchLineReviewStore extends JdbcAccountPatchLineReviewSto
       SitePaths sitePaths,
       ThreadSettingsConfig threadSettingsConfig) {
     super(cfg, sitePaths, threadSettingsConfig);
+  }
+
+  @VisibleForTesting
+  H2AccountPatchLineReviewStore(DataSource dataSource) {
+    super(dataSource);
   }
 
   @Override

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -1,0 +1,453 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.schema;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.flogger.FluentLogger;
+import com.google.common.primitives.Ints;
+import com.google.gerrit.entities.Account;
+import com.google.gerrit.entities.Change;
+import com.google.gerrit.entities.PatchSet;
+import com.google.gerrit.exceptions.DuplicateKeyException;
+import com.google.gerrit.exceptions.StorageException;
+import com.google.gerrit.extensions.api.changes.LineReviewedInput;
+import com.google.gerrit.extensions.client.Side;
+import com.google.gerrit.extensions.events.LifecycleListener;
+import com.google.gerrit.extensions.registration.DynamicItem;
+import com.google.gerrit.lifecycle.LifecycleModule;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore;
+import com.google.gerrit.server.config.ConfigUtil;
+import com.google.gerrit.server.config.GerritServerConfig;
+import com.google.gerrit.server.config.SitePaths;
+import com.google.gerrit.server.config.ThreadSettingsConfig;
+import com.google.gerrit.server.logging.Metadata;
+import com.google.gerrit.server.logging.TraceContext;
+import com.google.gerrit.server.logging.TraceContext.TraceTimer;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.eclipse.jgit.lib.Config;
+
+public abstract class JdbcAccountPatchLineReviewStore
+    implements AccountPatchLineReviewStore, LifecycleListener {
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  @VisibleForTesting
+  public static final String TEST_IN_MEMORY_URL =
+      "jdbc:h2:mem:account_patch_line_reviews;DB_CLOSE_DELAY=-1";
+  private static final String ACCOUNT_PATCH_LINE_REVIEW_DB = "accountPatchLineReviewDb";
+  private static final String ACCOUNT_PATCH_REVIEW_DB = "accountPatchReviewDb";
+  private static final String H2_DB = "h2";
+  private static final String MARIADB = "mariadb";
+  private static final String MYSQL = "mysql";
+  private static final String POSTGRESQL = "postgresql";
+  private static final String CLOUDSPANNER = "cloudspanner";
+  private static final String URL = "url";
+
+  public static class JdbcAccountPatchLineReviewStoreModule extends LifecycleModule {
+    private final Config cfg;
+
+    public JdbcAccountPatchLineReviewStoreModule(Config cfg) {
+      this.cfg = cfg;
+    }
+
+    @Override
+    protected void configure() {
+      Class<? extends JdbcAccountPatchLineReviewStore> impl;
+      String url = cfg.getString(ACCOUNT_PATCH_LINE_REVIEW_DB, null, URL);
+      if (url == null) {
+        url = cfg.getString(ACCOUNT_PATCH_REVIEW_DB, null, URL);
+      }
+      if (url == null || url.contains(H2_DB)) {
+        impl = H2AccountPatchLineReviewStore.class;
+      } else if (url.contains(POSTGRESQL)) {
+        impl = PostgresqlAccountPatchLineReviewStore.class;
+      } else if (url.contains(MYSQL)) {
+        impl = MysqlAccountPatchLineReviewStore.class;
+      } else if (url.contains(MARIADB)) {
+        impl = MariaDBAccountPatchLineReviewStore.class;
+      } else if (url.contains(CLOUDSPANNER)) {
+        impl = CloudSpannerAccountPatchLineReviewStore.class;
+      } else {
+        throw new IllegalArgumentException(
+            "unsupported driver type for account patch line review db: " + url);
+      }
+      DynamicItem.bind(binder(), AccountPatchLineReviewStore.class).to(impl);
+      listener().to(impl);
+    }
+  }
+
+  private DataSource ds;
+
+  protected JdbcAccountPatchLineReviewStore(
+      Config cfg, SitePaths sitePaths, ThreadSettingsConfig threadSettingsConfig) {
+    this.ds = createDataSource(cfg, sitePaths, threadSettingsConfig);
+  }
+
+  private static String getUrl(@GerritServerConfig Config cfg, SitePaths sitePaths) {
+    String url = cfg.getString(ACCOUNT_PATCH_LINE_REVIEW_DB, null, URL);
+    if (url == null) {
+      url = cfg.getString(ACCOUNT_PATCH_REVIEW_DB, null, URL);
+    }
+    if (url == null) {
+      return createH2Url(sitePaths.db_dir.resolve("account_patch_reviews"));
+    }
+    return url;
+  }
+
+  private static DataSource createDataSource(
+      Config cfg, SitePaths sitePaths, ThreadSettingsConfig threadSettingsConfig) {
+    BasicDataSource datasource = new BasicDataSource();
+    String url = getUrl(cfg, sitePaths);
+    String configSection =
+        cfg.getString(ACCOUNT_PATCH_LINE_REVIEW_DB, null, URL) != null
+            ? ACCOUNT_PATCH_LINE_REVIEW_DB
+            : ACCOUNT_PATCH_REVIEW_DB;
+    int poolLimit = threadSettingsConfig.getDatabasePoolLimit();
+    datasource.setUrl(url);
+    datasource.setDriverClassName(getDriverFromUrl(url));
+    datasource.setMaxActive(cfg.getInt(configSection, "poolLimit", poolLimit));
+    datasource.setMinIdle(cfg.getInt(configSection, "poolminidle", 4));
+    datasource.setMaxIdle(
+        cfg.getInt(configSection, "poolmaxidle", Math.min(poolLimit, 16)));
+    datasource.setInitialSize(datasource.getMinIdle());
+    datasource.setMaxWait(
+        ConfigUtil.getTimeUnit(
+            cfg,
+            configSection,
+            null,
+            "poolmaxwait",
+            MILLISECONDS.convert(30, SECONDS),
+            MILLISECONDS));
+    long evictIdleTimeMs = 1000L * 60;
+    datasource.setMinEvictableIdleTimeMillis(evictIdleTimeMs);
+    datasource.setTimeBetweenEvictionRunsMillis(evictIdleTimeMs / 2);
+    return datasource;
+  }
+
+  private static String getDriverFromUrl(String url) {
+    if (url.contains(POSTGRESQL)) {
+      return "org.postgresql.Driver";
+    }
+    if (url.contains(MYSQL)) {
+      return "com.mysql.jdbc.Driver";
+    }
+    if (url.contains(MARIADB)) {
+      return "org.mariadb.jdbc.Driver";
+    }
+    if (url.contains(CLOUDSPANNER)) {
+      return "com.google.cloud.spanner.jdbc.JdbcDriver";
+    }
+    return "org.h2.Driver";
+  }
+
+  private static String createH2Url(Path path) {
+    return "jdbc:h2:" + path.toUri().toString();
+  }
+
+  protected static short sideToShort(Side side) {
+    return side == Side.PARENT ? (short) 0 : (short) 1;
+  }
+
+  /** Normalize input to (lineNumber, startLine, startChar, endLine, endChar). */
+  protected static void normalizeInput(
+      LineReviewedInput input,
+      int[] lineNumber,
+      int[] startLine,
+      int[] startChar,
+      int[] endLine,
+      int[] endChar) {
+    int line = input.line != null && input.line > 0 ? input.line : 1;
+    lineNumber[0] = line;
+    if (input.range != null
+        && input.range.startLine > 0
+        && input.range.endLine > 0
+        && input.range.startLine <= input.range.endLine) {
+      startLine[0] = input.range.startLine;
+      startChar[0] = Math.max(0, input.range.startCharacter);
+      endLine[0] = input.range.endLine;
+      endChar[0] = Math.max(0, input.range.endCharacter);
+    } else {
+      startLine[0] = line;
+      startChar[0] = 0;
+      endLine[0] = line;
+      endChar[0] = 0;
+    }
+  }
+
+  @Override
+  public void start() {
+    try {
+      createTableIfNotExists();
+    } catch (StorageException e) {
+      logger
+          .atSevere()
+          .withCause(e)
+          .log("Failed to create table to store account patch line reviews");
+    }
+  }
+
+  public Connection getConnection() throws SQLException {
+    return ds.getConnection();
+  }
+
+  public void createTableIfNotExists() {
+    try (Connection con = ds.getConnection();
+        Statement stmt = con.createStatement()) {
+      doCreateTable(stmt);
+    } catch (SQLException e) {
+      throw convertError("create", e);
+    }
+  }
+
+  protected void doCreateTable(Statement stmt) throws SQLException {
+    stmt.executeUpdate(
+        "CREATE TABLE IF NOT EXISTS account_patch_line_reviews ("
+            + "account_id INTEGER DEFAULT 0 NOT NULL, "
+            + "change_id INTEGER DEFAULT 0 NOT NULL, "
+            + "patch_set_id INTEGER DEFAULT 0 NOT NULL, "
+            + "file_name VARCHAR(4096) DEFAULT '' NOT NULL, "
+            + "line_number INTEGER DEFAULT 1 NOT NULL, "
+            + "side SMALLINT DEFAULT 1 NOT NULL, "
+            + "start_line INTEGER DEFAULT 1 NOT NULL, "
+            + "start_char INTEGER DEFAULT 0 NOT NULL, "
+            + "end_line INTEGER DEFAULT 1 NOT NULL, "
+            + "end_char INTEGER DEFAULT 0 NOT NULL, "
+            + "CONSTRAINT primary_key_account_patch_line_reviews "
+            + "PRIMARY KEY (change_id, patch_set_id, account_id, file_name, line_number, side, "
+            + "start_line, start_char, end_line, end_char)"
+            + ")");
+  }
+
+  @Override
+  public void stop() {}
+
+  @Override
+  public boolean markLineReviewed(
+      PatchSet.Id psId, Account.Id accountId, String path, LineReviewedInput input) {
+    Side side = input.side != null ? input.side : Side.REVISION;
+    int[] lineNumber = new int[1];
+    int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
+    normalizeInput(input, lineNumber, startLine, startChar, endLine, endChar);
+
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "Mark line/region as reviewed",
+                Metadata.builder()
+                    .patchSetId(psId.get())
+                    .accountId(accountId.get())
+                    .filePath(path)
+                    .build());
+        Connection con = ds.getConnection();
+        PreparedStatement stmt =
+            con.prepareStatement(
+                "INSERT INTO account_patch_line_reviews "
+                    + "(account_id, change_id, patch_set_id, file_name, line_number, side, "
+                    + "start_line, start_char, end_line, end_char) VALUES "
+                    + "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+      stmt.setInt(1, accountId.get());
+      stmt.setInt(2, psId.changeId().get());
+      stmt.setInt(3, psId.get());
+      stmt.setString(4, path);
+      stmt.setInt(5, lineNumber[0]);
+      stmt.setShort(6, sideToShort(side));
+      stmt.setInt(7, startLine[0]);
+      stmt.setInt(8, startChar[0]);
+      stmt.setInt(9, endLine[0]);
+      stmt.setInt(10, endChar[0]);
+      stmt.executeUpdate();
+      return true;
+    } catch (SQLException e) {
+      StorageException ormException = convertError("insert", e);
+      if (ormException instanceof DuplicateKeyException) {
+        return false;
+      }
+      throw ormException;
+    }
+  }
+
+  @Override
+  public void markLineReviewed(
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      Collection<LineReviewedInput> inputs) {
+    if (inputs == null || inputs.isEmpty()) {
+      return;
+    }
+    for (LineReviewedInput input : inputs) {
+      var unused = markLineReviewed(psId, accountId, path, input);
+    }
+  }
+
+  @Override
+  public void clearLineReviewed(
+      PatchSet.Id psId, Account.Id accountId, String path, LineReviewedInput input) {
+    Side side = input.side != null ? input.side : Side.REVISION;
+    int[] lineNumber = new int[1];
+    int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
+    normalizeInput(input, lineNumber, startLine, startChar, endLine, endChar);
+
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "Clear line/region reviewed flag",
+                Metadata.builder()
+                    .patchSetId(psId.get())
+                    .accountId(accountId.get())
+                    .filePath(path)
+                    .build());
+        Connection con = ds.getConnection();
+        PreparedStatement stmt =
+            con.prepareStatement(
+                "DELETE FROM account_patch_line_reviews WHERE account_id = ? AND change_id = ? "
+                    + "AND patch_set_id = ? AND file_name = ? AND line_number = ? AND side = ? "
+                    + "AND start_line = ? AND start_char = ? AND end_line = ? AND end_char = ?")) {
+      stmt.setInt(1, accountId.get());
+      stmt.setInt(2, psId.changeId().get());
+      stmt.setInt(3, psId.get());
+      stmt.setString(4, path);
+      stmt.setInt(5, lineNumber[0]);
+      stmt.setShort(6, sideToShort(side));
+      stmt.setInt(7, startLine[0]);
+      stmt.setInt(8, startChar[0]);
+      stmt.setInt(9, endLine[0]);
+      stmt.setInt(10, endChar[0]);
+      stmt.executeUpdate();
+    } catch (SQLException e) {
+      throw convertError("delete", e);
+    }
+  }
+
+  @Override
+  public void clearLineReviewed(PatchSet.Id psId) {
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "Clear all line reviewed flags of patch set",
+                Metadata.builder().patchSetId(psId.get()).build());
+        Connection con = ds.getConnection();
+        PreparedStatement stmt =
+            con.prepareStatement(
+                "DELETE FROM account_patch_line_reviews WHERE change_id = ? AND patch_set_id = ?")) {
+      stmt.setInt(1, psId.changeId().get());
+      stmt.setInt(2, psId.get());
+      stmt.executeUpdate();
+    } catch (SQLException e) {
+      throw convertError("delete", e);
+    }
+  }
+
+  @Override
+  public void clearLineReviewed(Change.Id changeId) {
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "Clear all line reviewed flags of change",
+                Metadata.builder().changeId(changeId.get()).build());
+        Connection con = ds.getConnection();
+        PreparedStatement stmt =
+            con.prepareStatement("DELETE FROM account_patch_line_reviews WHERE change_id = ?")) {
+      stmt.setInt(1, changeId.get());
+      stmt.executeUpdate();
+    } catch (SQLException e) {
+      throw convertError("delete", e);
+    }
+  }
+
+  @Override
+  public Optional<PatchSetWithReviewedLines> findReviewedLines(
+      PatchSet.Id psId, Account.Id accountId, String path) {
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "Find line reviewed flags",
+                Metadata.builder()
+                    .patchSetId(psId.get())
+                    .accountId(accountId.get())
+                    .build());
+        Connection con = ds.getConnection()) {
+      String sql =
+          "SELECT file_name, line_number, side, start_line, start_char, end_line, end_char "
+              + "FROM account_patch_line_reviews "
+              + "WHERE account_id = ? AND change_id = ? AND patch_set_id = ?";
+      if (path != null) {
+        sql += " AND file_name = ?";
+      }
+      sql += " ORDER BY file_name, line_number";
+      PreparedStatement stmt = con.prepareStatement(sql);
+      stmt.setInt(1, accountId.get());
+      stmt.setInt(2, psId.changeId().get());
+      stmt.setInt(3, psId.get());
+      if (path != null) {
+        stmt.setString(4, path);
+      }
+      try (ResultSet rs = stmt.executeQuery()) {
+        ImmutableList.Builder<ReviewedLine> builder = ImmutableList.builder();
+        while (rs.next()) {
+          builder.add(
+              ReviewedLine.create(
+                  rs.getString("file_name"),
+                  rs.getInt("line_number"),
+                  rs.getShort("side"),
+                  rs.getInt("start_line"),
+                  rs.getInt("start_char"),
+                  rs.getInt("end_line"),
+                  rs.getInt("end_char")));
+        }
+        ImmutableList<ReviewedLine> lines = builder.build();
+        if (lines.isEmpty()) {
+          return Optional.empty();
+        }
+        return Optional.of(PatchSetWithReviewedLines.create(psId, lines));
+      }
+    } catch (SQLException e) {
+      throw convertError("select", e);
+    }
+  }
+
+  public StorageException convertError(String op, SQLException err) {
+    if (err.getCause() == null && err.getNextException() != null) {
+      err.initCause(err.getNextException());
+    }
+    return new StorageException(op + " failure on account_patch_line_reviews", err);
+  }
+
+  protected static int getSQLStateInt(SQLException err) {
+    String s = getSQLState(err);
+    if (s != null) {
+      Integer i = Ints.tryParse(s);
+      return i != null ? i : -1;
+    }
+    return 0;
+  }
+
+  private static String getSQLState(SQLException err) {
+    String ec;
+    SQLException next = err;
+    do {
+      ec = next.getSQLState();
+      next = next.getNextException();
+    } while (ec == null && next != null);
+    return ec;
+  }
+}

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -107,6 +107,23 @@ public abstract class JdbcAccountPatchLineReviewStore
     this.ds = createDataSource(cfg, sitePaths, threadSettingsConfig);
   }
 
+  @VisibleForTesting
+  protected JdbcAccountPatchLineReviewStore(DataSource dataSource) {
+    this.ds = dataSource;
+  }
+
+  @VisibleForTesting
+  public static H2AccountPatchLineReviewStore createInMemoryForTesting() {
+    BasicDataSource ds = new BasicDataSource();
+    ds.setUrl(TEST_IN_MEMORY_URL);
+    ds.setDriverClassName("org.h2.Driver");
+    ds.setMaxActive(4);
+    ds.setMinIdle(1);
+    ds.setMaxIdle(4);
+    ds.setInitialSize(1);
+    return new H2AccountPatchLineReviewStore(ds);
+  }
+
   private static String getUrl(@GerritServerConfig Config cfg, SitePaths sitePaths) {
     String url = cfg.getString(ACCOUNT_PATCH_LINE_REVIEW_DB, null, URL);
     if (url == null) {
@@ -376,6 +393,22 @@ public abstract class JdbcAccountPatchLineReviewStore
   }
 
   @Override
+  public void clearLineReviewedBy(Account.Id accountId) {
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "Clear all line reviewed flags of account",
+                Metadata.builder().accountId(accountId.get()).build());
+        Connection con = ds.getConnection();
+        PreparedStatement stmt =
+            con.prepareStatement("DELETE FROM account_patch_line_reviews WHERE account_id = ?")) {
+      stmt.setInt(1, accountId.get());
+      stmt.executeUpdate();
+    } catch (SQLException e) {
+      throw convertError("delete", e);
+    }
+  }
+
+  @Override
   public Optional<PatchSetWithReviewedLines> findReviewedLines(
       PatchSet.Id psId, Account.Id accountId, String path) {
     try (TraceTimer ignored =
@@ -394,31 +427,32 @@ public abstract class JdbcAccountPatchLineReviewStore
         sql += " AND file_name = ?";
       }
       sql += " ORDER BY file_name, line_number";
-      PreparedStatement stmt = con.prepareStatement(sql);
-      stmt.setInt(1, accountId.get());
-      stmt.setInt(2, psId.changeId().get());
-      stmt.setInt(3, psId.get());
-      if (path != null) {
-        stmt.setString(4, path);
-      }
-      try (ResultSet rs = stmt.executeQuery()) {
-        ImmutableList.Builder<ReviewedLine> builder = ImmutableList.builder();
-        while (rs.next()) {
-          builder.add(
-              ReviewedLine.create(
-                  rs.getString("file_name"),
-                  rs.getInt("line_number"),
-                  rs.getShort("side"),
-                  rs.getInt("start_line"),
-                  rs.getInt("start_char"),
-                  rs.getInt("end_line"),
-                  rs.getInt("end_char")));
+      try (PreparedStatement stmt = con.prepareStatement(sql)) {
+        stmt.setInt(1, accountId.get());
+        stmt.setInt(2, psId.changeId().get());
+        stmt.setInt(3, psId.get());
+        if (path != null) {
+          stmt.setString(4, path);
         }
-        ImmutableList<ReviewedLine> lines = builder.build();
-        if (lines.isEmpty()) {
-          return Optional.empty();
+        try (ResultSet rs = stmt.executeQuery()) {
+          ImmutableList.Builder<ReviewedLine> builder = ImmutableList.builder();
+          while (rs.next()) {
+            builder.add(
+                ReviewedLine.create(
+                    rs.getString("file_name"),
+                    rs.getInt("line_number"),
+                    rs.getShort("side"),
+                    rs.getInt("start_line"),
+                    rs.getInt("start_char"),
+                    rs.getInt("end_line"),
+                    rs.getInt("end_char")));
+          }
+          ImmutableList<ReviewedLine> lines = builder.build();
+          if (lines.isEmpty()) {
+            return Optional.empty();
+          }
+          return Optional.of(PatchSetWithReviewedLines.create(psId, lines));
         }
-        return Optional.of(PatchSetWithReviewedLines.create(psId, lines));
       }
     } catch (SQLException e) {
       throw convertError("select", e);

--- a/java/com/google/gerrit/server/schema/MariaDBAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/MariaDBAccountPatchLineReviewStore.java
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.schema;
+
+import com.google.gerrit.exceptions.DuplicateKeyException;
+import com.google.gerrit.exceptions.StorageException;
+import com.google.gerrit.server.config.GerritServerConfig;
+import com.google.gerrit.server.config.SitePaths;
+import com.google.gerrit.server.config.ThreadSettingsConfig;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.eclipse.jgit.lib.Config;
+
+@Singleton
+public class MariaDBAccountPatchLineReviewStore extends JdbcAccountPatchLineReviewStore {
+
+  @Inject
+  MariaDBAccountPatchLineReviewStore(
+      @GerritServerConfig Config cfg,
+      SitePaths sitePaths,
+      ThreadSettingsConfig threadSettingsConfig) {
+    super(cfg, sitePaths, threadSettingsConfig);
+  }
+
+  @Override
+  public StorageException convertError(String op, SQLException err) {
+    switch (err.getErrorCode()) {
+      case 1022, 1062, 1169 -> {
+        return new DuplicateKeyException("ACCOUNT_PATCH_LINE_REVIEWS", err);
+      }
+      default -> {
+        if (err.getCause() == null && err.getNextException() != null) {
+          err.initCause(err.getNextException());
+        }
+        return new StorageException(op + " failure on ACCOUNT_PATCH_LINE_REVIEWS", err);
+      }
+    }
+  }
+
+  @Override
+  protected void doCreateTable(Statement stmt) throws SQLException {
+    stmt.executeUpdate(
+        "CREATE TABLE IF NOT EXISTS account_patch_line_reviews ("
+            + "account_id INTEGER DEFAULT 0 NOT NULL, "
+            + "change_id INTEGER DEFAULT 0 NOT NULL, "
+            + "patch_set_id INTEGER DEFAULT 0 NOT NULL, "
+            + "file_name VARCHAR(255) DEFAULT '' NOT NULL, "
+            + "line_number INTEGER DEFAULT 1 NOT NULL, "
+            + "side SMALLINT DEFAULT 1 NOT NULL, "
+            + "start_line INTEGER DEFAULT 1 NOT NULL, "
+            + "start_char INTEGER DEFAULT 0 NOT NULL, "
+            + "end_line INTEGER DEFAULT 1 NOT NULL, "
+            + "end_char INTEGER DEFAULT 0 NOT NULL, "
+            + "CONSTRAINT primary_key_account_patch_line_reviews "
+            + "PRIMARY KEY (change_id, patch_set_id, account_id, file_name, line_number, side, "
+            + "start_line, start_char, end_line, end_char)"
+            + ")");
+  }
+}

--- a/java/com/google/gerrit/server/schema/MysqlAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/MysqlAccountPatchLineReviewStore.java
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.schema;
+
+import com.google.gerrit.exceptions.DuplicateKeyException;
+import com.google.gerrit.exceptions.StorageException;
+import com.google.gerrit.server.config.GerritServerConfig;
+import com.google.gerrit.server.config.SitePaths;
+import com.google.gerrit.server.config.ThreadSettingsConfig;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.eclipse.jgit.lib.Config;
+
+@Singleton
+public class MysqlAccountPatchLineReviewStore extends JdbcAccountPatchLineReviewStore {
+
+  @Inject
+  MysqlAccountPatchLineReviewStore(
+      @GerritServerConfig Config cfg,
+      SitePaths sitePaths,
+      ThreadSettingsConfig threadSettingsConfig) {
+    super(cfg, sitePaths, threadSettingsConfig);
+  }
+
+  @Override
+  public StorageException convertError(String op, SQLException err) {
+    switch (err.getErrorCode()) {
+      case 1022, 1062, 1169 -> {
+        return new DuplicateKeyException("ACCOUNT_PATCH_LINE_REVIEWS", err);
+      }
+      default -> {
+        if (err.getCause() == null && err.getNextException() != null) {
+          err.initCause(err.getNextException());
+        }
+        return new StorageException(op + " failure on ACCOUNT_PATCH_LINE_REVIEWS", err);
+      }
+    }
+  }
+
+  @Override
+  protected void doCreateTable(Statement stmt) throws SQLException {
+    stmt.executeUpdate(
+        "CREATE TABLE IF NOT EXISTS account_patch_line_reviews ("
+            + "account_id INTEGER DEFAULT 0 NOT NULL, "
+            + "change_id INTEGER DEFAULT 0 NOT NULL, "
+            + "patch_set_id INTEGER DEFAULT 0 NOT NULL, "
+            + "file_name VARCHAR(255) DEFAULT '' NOT NULL, "
+            + "line_number INTEGER DEFAULT 1 NOT NULL, "
+            + "side SMALLINT DEFAULT 1 NOT NULL, "
+            + "start_line INTEGER DEFAULT 1 NOT NULL, "
+            + "start_char INTEGER DEFAULT 0 NOT NULL, "
+            + "end_line INTEGER DEFAULT 1 NOT NULL, "
+            + "end_char INTEGER DEFAULT 0 NOT NULL, "
+            + "CONSTRAINT primary_key_account_patch_line_reviews "
+            + "PRIMARY KEY (change_id, patch_set_id, account_id, file_name, line_number, side, "
+            + "start_line, start_char, end_line, end_char)"
+            + ")");
+  }
+}

--- a/java/com/google/gerrit/server/schema/PostgresqlAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/PostgresqlAccountPatchLineReviewStore.java
@@ -1,0 +1,58 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.schema;
+
+import com.google.gerrit.exceptions.DuplicateKeyException;
+import com.google.gerrit.exceptions.StorageException;
+import com.google.gerrit.server.config.GerritServerConfig;
+import com.google.gerrit.server.config.SitePaths;
+import com.google.gerrit.server.config.ThreadSettingsConfig;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.sql.SQLException;
+import org.eclipse.jgit.lib.Config;
+
+@Singleton
+public class PostgresqlAccountPatchLineReviewStore extends JdbcAccountPatchLineReviewStore {
+
+  @Inject
+  PostgresqlAccountPatchLineReviewStore(
+      @GerritServerConfig Config cfg,
+      SitePaths sitePaths,
+      ThreadSettingsConfig threadSettingsConfig) {
+    super(cfg, sitePaths, threadSettingsConfig);
+  }
+
+  @Override
+  public StorageException convertError(String op, SQLException err) {
+    switch (getSQLStateInt(err)) {
+      case 23505 -> {
+        return new DuplicateKeyException("ACCOUNT_PATCH_LINE_REVIEWS", err);
+      }
+      case 23514, 23503, 23502, 23001 -> {
+        if (err.getCause() == null && err.getNextException() != null) {
+          err.initCause(err.getNextException());
+        }
+        return new StorageException(op + " failure on ACCOUNT_PATCH_LINE_REVIEWS", err);
+      }
+      default -> {
+        if (err.getCause() == null && err.getNextException() != null) {
+          err.initCause(err.getNextException());
+        }
+        return new StorageException(op + " failure on ACCOUNT_PATCH_LINE_REVIEWS", err);
+      }
+    }
+  }
+}

--- a/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
@@ -1,0 +1,249 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.testing;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.gerrit.entities.Account;
+import com.google.gerrit.entities.Change;
+import com.google.gerrit.entities.PatchSet;
+import com.google.gerrit.extensions.api.changes.LineReviewedInput;
+import com.google.gerrit.extensions.client.Side;
+import com.google.gerrit.extensions.events.LifecycleListener;
+import com.google.gerrit.extensions.registration.DynamicItem;
+import com.google.gerrit.lifecycle.LifecycleModule;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore;
+import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * In-memory implementation of {@link AccountPatchLineReviewStore} for tests.
+ */
+@Singleton
+public class FakeAccountPatchLineReviewStore
+    implements AccountPatchLineReviewStore, LifecycleListener {
+
+  private final Set<LineEntity> store = new HashSet<>();
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+
+  public static class FakeAccountPatchLineReviewStoreModule extends LifecycleModule {
+    @Override
+    protected void configure() {
+      DynamicItem.bind(binder(), AccountPatchLineReviewStore.class)
+          .to(FakeAccountPatchLineReviewStore.class);
+      listener().to(FakeAccountPatchLineReviewStore.class);
+    }
+  }
+
+  @AutoValue
+  abstract static class LineEntity {
+    abstract PatchSet.Id psId();
+
+    abstract Account.Id accountId();
+
+    abstract String path();
+
+    abstract int lineNumber();
+
+    abstract short side();
+
+    abstract int startLine();
+
+    abstract int startChar();
+
+    abstract int endLine();
+
+    abstract int endChar();
+
+    static LineEntity create(
+        PatchSet.Id psId,
+        Account.Id accountId,
+        String path,
+        int lineNumber,
+        short side,
+        int startLine,
+        int startChar,
+        int endLine,
+        int endChar) {
+      return new AutoValue_FakeAccountPatchLineReviewStore_LineEntity(
+          psId, accountId, path, lineNumber, side, startLine, startChar, endLine, endChar);
+    }
+  }
+
+  private static void normalize(
+      LineReviewedInput input,
+      int[] lineNumber,
+      int[] startLine,
+      int[] startChar,
+      int[] endLine,
+      int[] endChar) {
+    int line = input.line != null && input.line > 0 ? input.line : 1;
+    lineNumber[0] = line;
+    if (input.range != null
+        && input.range.startLine > 0
+        && input.range.endLine > 0
+        && input.range.startLine <= input.range.endLine) {
+      startLine[0] = input.range.startLine;
+      startChar[0] = Math.max(0, input.range.startCharacter);
+      endLine[0] = input.range.endLine;
+      endChar[0] = Math.max(0, input.range.endCharacter);
+    } else {
+      startLine[0] = line;
+      startChar[0] = 0;
+      endLine[0] = line;
+      endChar[0] = 0;
+    }
+  }
+
+  @Override
+  public boolean markLineReviewed(
+      PatchSet.Id psId, Account.Id accountId, String path, LineReviewedInput input) {
+    Side side = input.side != null ? input.side : Side.REVISION;
+    short sideShort = side == Side.PARENT ? (short) 0 : (short) 1;
+    int[] lineNumber = new int[1];
+    int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
+    normalize(input, lineNumber, startLine, startChar, endLine, endChar);
+
+    synchronized (store) {
+      LineEntity entity =
+          LineEntity.create(
+              psId,
+              accountId,
+              path,
+              lineNumber[0],
+              sideShort,
+              startLine[0],
+              startChar[0],
+              endLine[0],
+              endChar[0]);
+      return store.add(entity);
+    }
+  }
+
+  @Override
+  public void markLineReviewed(
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      Collection<LineReviewedInput> inputs) {
+    inputs.forEach(
+        input -> {
+          var unused = markLineReviewed(psId, accountId, path, input);
+        });
+  }
+
+  @Override
+  public void clearLineReviewed(
+      PatchSet.Id psId, Account.Id accountId, String path, LineReviewedInput input) {
+    Side side = input.side != null ? input.side : Side.REVISION;
+    short sideShort = side == Side.PARENT ? (short) 0 : (short) 1;
+    int[] lineNumber = new int[1];
+    int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
+    normalize(input, lineNumber, startLine, startChar, endLine, endChar);
+
+    synchronized (store) {
+      store.remove(
+          LineEntity.create(
+              psId,
+              accountId,
+              path,
+              lineNumber[0],
+              sideShort,
+              startLine[0],
+              startChar[0],
+              endLine[0],
+              endChar[0]));
+    }
+  }
+
+  @Override
+  public void clearLineReviewed(PatchSet.Id psId) {
+    synchronized (store) {
+      List<LineEntity> toRemove = new ArrayList<>();
+      for (LineEntity entity : store) {
+        if (entity.psId().equals(psId)) {
+          toRemove.add(entity);
+        }
+      }
+      store.removeAll(toRemove);
+    }
+  }
+
+  @Override
+  public void clearLineReviewed(Change.Id changeId) {
+    synchronized (store) {
+      List<LineEntity> toRemove = new ArrayList<>();
+      for (LineEntity entity : store) {
+        if (entity.psId().changeId().equals(changeId)) {
+          toRemove.add(entity);
+        }
+      }
+      store.removeAll(toRemove);
+    }
+  }
+
+  @Override
+  public void clearLineReviewedBy(Account.Id accountId) {
+    synchronized (store) {
+      List<LineEntity> toRemove = new ArrayList<>();
+      for (LineEntity entity : store) {
+        if (entity.accountId().equals(accountId)) {
+          toRemove.add(entity);
+        }
+      }
+      store.removeAll(toRemove);
+    }
+  }
+
+  @Override
+  public Optional<PatchSetWithReviewedLines> findReviewedLines(
+      PatchSet.Id psId, Account.Id accountId, String path) {
+    synchronized (store) {
+      ImmutableList.Builder<ReviewedLine> builder = ImmutableList.builder();
+      for (LineEntity entity : store) {
+        if (!entity.accountId().equals(accountId) || !entity.psId().equals(psId)) {
+          continue;
+        }
+        if (path != null && !path.equals(entity.path())) {
+          continue;
+        }
+        builder.add(
+            ReviewedLine.create(
+                entity.path(),
+                entity.lineNumber(),
+                entity.side(),
+                entity.startLine(),
+                entity.startChar(),
+                entity.endLine(),
+                entity.endChar()));
+      }
+      ImmutableList<ReviewedLine> lines = builder.build();
+      if (lines.isEmpty()) {
+        return Optional.empty();
+      }
+      return Optional.of(PatchSetWithReviewedLines.create(psId, lines));
+    }
+  }
+}

--- a/java/com/google/gerrit/testing/InMemoryModule.java
+++ b/java/com/google/gerrit/testing/InMemoryModule.java
@@ -121,6 +121,7 @@ import com.google.gerrit.server.query.change.ChangeNumberBitmapMaskAlgorithm;
 import com.google.gerrit.server.query.change.ChangeNumberNoopAlgorithm;
 import com.google.gerrit.server.query.change.ChangeNumberVirtualIdAlgorithm;
 import com.google.gerrit.server.restapi.RestApiModule;
+import com.google.gerrit.server.schema.JdbcAccountPatchLineReviewStore;
 import com.google.gerrit.server.schema.JdbcAccountPatchReviewStore;
 import com.google.gerrit.server.schema.SchemaCreator;
 import com.google.gerrit.server.schema.SchemaCreatorImpl;
@@ -159,6 +160,9 @@ public class InMemoryModule extends FactoryModule {
   }
 
   public static void setDefaults(Config cfg) {
+    cfg.setString(
+        "accountPatchLineReviewDb", null, "url",
+        JdbcAccountPatchLineReviewStore.TEST_IN_MEMORY_URL);
     cfg.setString(
         "accountPatchReviewDb", null, "url", JdbcAccountPatchReviewStore.TEST_IN_MEMORY_URL);
     cfg.setEnum("auth", null, "type", AuthType.DEVELOPMENT_BECOME_ANY_ACCOUNT);

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -56,6 +56,8 @@ import com.google.gerrit.acceptance.testsuite.account.AccountOperations;
 import com.google.gerrit.acceptance.testsuite.change.ChangeOperations;
 import com.google.gerrit.acceptance.testsuite.project.ProjectOperations;
 import com.google.gerrit.acceptance.testsuite.request.RequestScopeOperations;
+import com.google.gerrit.acceptance.testsuite.project.ProjectOperations;
+import com.google.gerrit.acceptance.testsuite.request.RequestScopeOperations;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.BranchNameKey;
 import com.google.gerrit.entities.BranchOrderSection;
@@ -66,6 +68,10 @@ import com.google.gerrit.entities.PatchSetApproval;
 import com.google.gerrit.entities.Permission;
 import com.google.gerrit.entities.Project;
 import com.google.gerrit.entities.RefNames;
+import com.google.gerrit.extensions.api.changes.LineReviewedInput;
+import com.google.gerrit.extensions.api.changes.LineReviewedInput;
+import com.google.gerrit.extensions.client.Side;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore;
 import com.google.gerrit.extensions.api.changes.ChangeApi;
 import com.google.gerrit.extensions.api.changes.CherryPickInput;
 import com.google.gerrit.extensions.api.changes.DraftApi;
@@ -138,6 +144,7 @@ public class RevisionIT extends AbstractDaemonTest {
   @Inject private ExtensionRegistry extensionRegistry;
   @Inject private AccountOperations accountOperations;
   @Inject private ChangeOperations changeOperations;
+  @Inject private AccountPatchLineReviewStore accountPatchLineReviewStore;
 
   @Test
   public void get() throws Exception {
@@ -1691,6 +1698,36 @@ public class RevisionIT extends AbstractDaemonTest {
     gApi.changes().id(r.getChangeId()).current().setReviewed(PushOneCommit.FILE_NAME, false);
 
     assertThat(gApi.changes().id(r.getChangeId()).current().reviewed()).isEmpty();
+  }
+
+  @Test
+  public void setUnsetLineReviewedFlag() throws Exception {
+    PushOneCommit push = pushFactory.create(admin.newIdent(), testRepo);
+    PushOneCommit.Result r = push.to("refs/for/master");
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 1;
+    input.side = Side.REVISION;
+
+    var unused =
+        accountPatchLineReviewStore.markLineReviewed(
+            r.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME, input);
+
+    Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> found =
+        accountPatchLineReviewStore.findReviewedLines(
+            r.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME);
+    assertThat(found).isPresent();
+    assertThat(found.get().lines()).hasSize(1);
+    assertThat(found.get().lines().get(0).lineNumber()).isEqualTo(1);
+    assertThat(found.get().lines().get(0).path()).isEqualTo(PushOneCommit.FILE_NAME);
+
+    accountPatchLineReviewStore.clearLineReviewed(
+        r.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME, input);
+
+    found =
+        accountPatchLineReviewStore.findReviewedLines(
+            r.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME);
+    assertThat(found).isEmpty();
   }
 
   @Test

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -69,8 +69,9 @@ import com.google.gerrit.entities.Permission;
 import com.google.gerrit.entities.Project;
 import com.google.gerrit.entities.RefNames;
 import com.google.gerrit.extensions.api.changes.LineReviewedInput;
-import com.google.gerrit.extensions.api.changes.LineReviewedInput;
 import com.google.gerrit.extensions.client.Side;
+import com.google.gerrit.extensions.common.LineReviewedInfo;
+import com.google.gson.reflect.TypeToken;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore;
 import com.google.gerrit.extensions.api.changes.ChangeApi;
 import com.google.gerrit.extensions.api.changes.CherryPickInput;
@@ -1728,6 +1729,128 @@ public class RevisionIT extends AbstractDaemonTest {
         accountPatchLineReviewStore.findReviewedLines(
             r.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME);
     assertThat(found).isEmpty();
+  }
+
+  // -- HTTP-level tests for the reviewed_lines REST endpoint --
+
+  private String reviewedLinesUrl(String changeId) {
+    return "/changes/" + changeId + "/revisions/current/files/" + FILE_NAME + "/reviewed_lines";
+  }
+
+  @Test
+  public void putReviewedLines_singleLine_returnsCreatedAndGetShowsLine() throws Exception {
+    PushOneCommit.Result r = createChange();
+    String url = reviewedLinesUrl(r.getChangeId());
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 5;
+    input.side = Side.REVISION;
+
+    RestResponse putResp = adminRestSession.put(url, input);
+    putResp.assertCreated();
+
+    RestResponse getResp = adminRestSession.get(url);
+    getResp.assertOK();
+    List<LineReviewedInfo> lines =
+        newGson().fromJson(getResp.getReader(), new TypeToken<List<LineReviewedInfo>>() {}.getType());
+    assertThat(lines).hasSize(1);
+    assertThat(lines.get(0).line).isEqualTo(5);
+    assertThat(lines.get(0).side).isEqualTo(Side.REVISION);
+  }
+
+  @Test
+  public void putReviewedLines_alreadyMarked_returnsOk() throws Exception {
+    PushOneCommit.Result r = createChange();
+    String url = reviewedLinesUrl(r.getChangeId());
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 5;
+
+    adminRestSession.put(url, input).assertCreated();
+    adminRestSession.put(url, input).assertOK();
+  }
+
+  @Test
+  public void getReviewedLines_noMarks_returnsEmptyList() throws Exception {
+    PushOneCommit.Result r = createChange();
+
+    RestResponse getResp = adminRestSession.get(reviewedLinesUrl(r.getChangeId()));
+    getResp.assertOK();
+    List<LineReviewedInfo> lines =
+        newGson().fromJson(getResp.getReader(), new TypeToken<List<LineReviewedInfo>>() {}.getType());
+    assertThat(lines).isEmpty();
+  }
+
+  @Test
+  public void putReviewedLines_lineZero_returnsBadRequest() throws Exception {
+    PushOneCommit.Result r = createChange();
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 0;
+
+    adminRestSession.put(reviewedLinesUrl(r.getChangeId()), input).assertBadRequest();
+  }
+
+  @Test
+  public void putReviewedLines_missingBody_returnsBadRequest() throws Exception {
+    PushOneCommit.Result r = createChange();
+
+    adminRestSession.put(reviewedLinesUrl(r.getChangeId())).assertBadRequest();
+  }
+
+  @Test
+  public void putReviewedLines_withRange_getReturnsRange() throws Exception {
+    PushOneCommit.Result r = createChange();
+    String url = reviewedLinesUrl(r.getChangeId());
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 10;
+    input.side = Side.REVISION;
+    com.google.gerrit.extensions.client.Comment.Range range =
+        new com.google.gerrit.extensions.client.Comment.Range();
+    range.startLine = 10;
+    range.startCharacter = 2;
+    range.endLine = 12;
+    range.endCharacter = 5;
+    input.range = range;
+
+    adminRestSession.put(url, input).assertCreated();
+
+    RestResponse getResp = adminRestSession.get(url);
+    getResp.assertOK();
+    List<LineReviewedInfo> lines =
+        newGson().fromJson(getResp.getReader(), new TypeToken<List<LineReviewedInfo>>() {}.getType());
+    assertThat(lines).hasSize(1);
+    assertThat(lines.get(0).line).isEqualTo(10);
+    assertThat(lines.get(0).range).isNotNull();
+    assertThat(lines.get(0).range.startLine).isEqualTo(10);
+    assertThat(lines.get(0).range.endLine).isEqualTo(12);
+  }
+
+  @Test
+  public void putReviewedLines_parentSide_getReturnsParent() throws Exception {
+    PushOneCommit.Result r = createChange();
+    String url = reviewedLinesUrl(r.getChangeId());
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 3;
+    input.side = Side.PARENT;
+
+    adminRestSession.put(url, input).assertCreated();
+
+    RestResponse getResp = adminRestSession.get(url);
+    getResp.assertOK();
+    List<LineReviewedInfo> lines =
+        newGson().fromJson(getResp.getReader(), new TypeToken<List<LineReviewedInfo>>() {}.getType());
+    assertThat(lines).hasSize(1);
+    assertThat(lines.get(0).side).isEqualTo(Side.PARENT);
+  }
+
+  @Test
+  public void deleteReviewedLines_withoutBody_returnsBadRequest() throws Exception {
+    PushOneCommit.Result r = createChange();
+
+    adminRestSession.delete(reviewedLinesUrl(r.getChangeId())).assertBadRequest();
   }
 
   @Test

--- a/javatests/com/google/gerrit/acceptance/rest/binding/ChangesRestApiBindingsIT.java
+++ b/javatests/com/google/gerrit/acceptance/rest/binding/ChangesRestApiBindingsIT.java
@@ -217,7 +217,10 @@ public class ChangesRestApiBindingsIT extends AbstractDaemonTest {
           RestCall.get("/changes/%s/revisions/%s/files/%s/diff"),
           RestCall.get("/changes/%s/revisions/%s/files/%s/download"),
           RestCall.put("/changes/%s/revisions/%s/files/%s/reviewed"),
-          RestCall.delete("/changes/%s/revisions/%s/files/%s/reviewed"));
+          RestCall.delete("/changes/%s/revisions/%s/files/%s/reviewed"),
+          RestCall.get("/changes/%s/revisions/%s/files/%s/reviewed_lines"),
+          RestCall.put("/changes/%s/revisions/%s/files/%s/reviewed_lines"),
+          RestCall.delete("/changes/%s/revisions/%s/files/%s/reviewed_lines"));
 
   /**
    * Change message REST endpoints to be tested, each URL contains placeholders for the change

--- a/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
+++ b/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
@@ -1,0 +1,229 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.schema;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.gerrit.entities.Account;
+import com.google.gerrit.entities.Change;
+import com.google.gerrit.entities.PatchSet;
+import com.google.gerrit.extensions.api.changes.LineReviewedInput;
+import com.google.gerrit.extensions.client.Comment.Range;
+import com.google.gerrit.extensions.client.Side;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.PatchSetWithReviewedLines;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.ReviewedLine;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Optional;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link JdbcAccountPatchLineReviewStore} using an in-memory H2 database.
+ *
+ * <p>These tests exercise the real SQL layer (INSERT, SELECT, DELETE) and verify that the JDBC
+ * implementation correctly stores and retrieves line/region reviewed flags.
+ */
+public class JdbcAccountPatchLineReviewStoreTest {
+
+  private static final Account.Id ACCOUNT_1 = Account.id(1);
+  private static final Account.Id ACCOUNT_2 = Account.id(2);
+  private static final Change.Id CHANGE_1 = Change.id(100);
+  private static final PatchSet.Id PS_1 = PatchSet.id(CHANGE_1, 1);
+  private static final PatchSet.Id PS_2 = PatchSet.id(CHANGE_1, 2);
+  private static final String FILE_A = "src/Main.java";
+  private static final String FILE_B = "src/Util.java";
+
+  private H2AccountPatchLineReviewStore store;
+
+  @Before
+  public void setUp() {
+    store = JdbcAccountPatchLineReviewStore.createInMemoryForTesting();
+    store.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    try (Connection con = store.getConnection();
+        Statement stmt = con.createStatement()) {
+      stmt.executeUpdate("DROP TABLE IF EXISTS account_patch_line_reviews");
+    }
+  }
+
+  // -- helpers --
+
+  private static LineReviewedInput lineInput(int line) {
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = line;
+    input.side = Side.REVISION;
+    return input;
+  }
+
+  private static LineReviewedInput lineInput(int line, Side side) {
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = line;
+    input.side = side;
+    return input;
+  }
+
+  private static LineReviewedInput rangeInput(int line, int startLine, int startChar, int endLine, int endChar) {
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = line;
+    input.side = Side.REVISION;
+    Range range = new Range();
+    range.startLine = startLine;
+    range.startCharacter = startChar;
+    range.endLine = endLine;
+    range.endCharacter = endChar;
+    input.range = range;
+    return input;
+  }
+
+  // -- tests --
+
+  @Test
+  public void markAndFindLine() {
+    var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+
+    Optional<PatchSetWithReviewedLines> result = store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().lines()).hasSize(1);
+    ReviewedLine line = result.get().lines().get(0);
+    assertThat(line.lineNumber()).isEqualTo(5);
+    assertThat(line.path()).isEqualTo(FILE_A);
+    assertThat(line.getSide()).isEqualTo(Side.REVISION);
+  }
+
+  @Test
+  public void markIdempotent() {
+    boolean first = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+    boolean second = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+
+    assertThat(first).isTrue();
+    assertThat(second).isFalse();
+
+    Optional<PatchSetWithReviewedLines> result = store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A);
+    assertThat(result).isPresent();
+    assertThat(result.get().lines()).hasSize(1);
+  }
+
+  @Test
+  public void clearExistingLine() {
+    var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+    store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+
+    Optional<PatchSetWithReviewedLines> result = store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void clearNonExistent_noException() {
+    // Should not throw even if the row does not exist.
+    store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(99));
+
+    assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A)).isEmpty();
+  }
+
+  @Test
+  public void isolationByAccount() {
+    var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+
+    assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A)).isPresent();
+    assertThat(store.findReviewedLines(PS_1, ACCOUNT_2, FILE_A)).isEmpty();
+  }
+
+  @Test
+  public void isolationByPatchSet() {
+    var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+
+    assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A)).isPresent();
+    assertThat(store.findReviewedLines(PS_2, ACCOUNT_1, FILE_A)).isEmpty();
+  }
+
+  @Test
+  public void findWithNullPath_returnsAllFiles() {
+    var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+    var unused2 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_B, lineInput(2));
+
+    Optional<PatchSetWithReviewedLines> all = store.findReviewedLines(PS_1, ACCOUNT_1, null);
+    assertThat(all).isPresent();
+    assertThat(all.get().lines()).hasSize(2);
+
+    Optional<PatchSetWithReviewedLines> fileA = store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A);
+    assertThat(fileA).isPresent();
+    assertThat(fileA.get().lines()).hasSize(1);
+    assertThat(fileA.get().lines().get(0).path()).isEqualTo(FILE_A);
+  }
+
+  @Test
+  public void markAndFindWithRange() {
+    var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, rangeInput(10, 10, 3, 12, 7));
+
+    Optional<PatchSetWithReviewedLines> result = store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A);
+    assertThat(result).isPresent();
+    ReviewedLine line = result.get().lines().get(0);
+    assertThat(line.lineNumber()).isEqualTo(10);
+    assertThat(line.startLine()).isEqualTo(10);
+    assertThat(line.startChar()).isEqualTo(3);
+    assertThat(line.endLine()).isEqualTo(12);
+    assertThat(line.endChar()).isEqualTo(7);
+  }
+
+  @Test
+  public void markParentSide() {
+    var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(3, Side.PARENT));
+
+    Optional<PatchSetWithReviewedLines> result = store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A);
+    assertThat(result).isPresent();
+    assertThat(result.get().lines().get(0).getSide()).isEqualTo(Side.PARENT);
+  }
+
+  @Test
+  public void clearByPatchSet_removesAllLinesForThatPatchSet() {
+    var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+    var unused2 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_B, lineInput(2));
+    var unused3 = store.markLineReviewed(PS_2, ACCOUNT_1, FILE_A, lineInput(3));
+
+    store.clearLineReviewed(PS_1);
+
+    assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, null)).isEmpty();
+    assertThat(store.findReviewedLines(PS_2, ACCOUNT_1, FILE_A)).isPresent();
+  }
+
+  @Test
+  public void clearByChangeId_removesAllPatchSetsForThatChange() {
+    var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+    var unused2 = store.markLineReviewed(PS_2, ACCOUNT_1, FILE_A, lineInput(2));
+
+    store.clearLineReviewed(CHANGE_1);
+
+    assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, null)).isEmpty();
+    assertThat(store.findReviewedLines(PS_2, ACCOUNT_1, null)).isEmpty();
+  }
+
+  @Test
+  public void clearLineReviewedBy_removesAllLinesForThatAccount() {
+    var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+    var unused2 = store.markLineReviewed(PS_1, ACCOUNT_2, FILE_A, lineInput(1));
+
+    store.clearLineReviewedBy(ACCOUNT_1);
+
+    assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A)).isEmpty();
+    assertThat(store.findReviewedLines(PS_1, ACCOUNT_2, FILE_A)).isPresent();
+  }
+}


### PR DESCRIPTION
## Summary 
- Add `GET/PUT/DELETE` `/changes/{id}/revisions/{rev}/files/{file}/reviewed_lines` REST endpoints for marking individual lines as reviewed 
- Introduce `AccountPatchLineReviewStore` interface with JDBC implementations for H2, PostgreSQL, MySQL, MariaDB, and Cloud Spanner
- Persist markers in a new `account_patch_line_reviews` table 
- Add `FakeAccountPatchLineReviewStore` for use in tests 

## Test Plan 
- [x] Unit tests (`JdbcAccountPatchLineReviewStoreTest`) against in-memory H2 (mark/clear/find, idempotency, account/patch set)
- [x] Acceptance tests over HTTP (status codes, response serialization, input validation)
- [x] Route binding tests confirming new endpoints