### PR TITLE
Implement backend support for viewing other reviewers' line markers

### DIFF
--- a/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
@@ -16,6 +16,7 @@ package com.google.gerrit.server.change;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
@@ -160,4 +161,17 @@ public interface AccountPatchLineReviewStore {
    */
   Optional<PatchSetWithReviewedLines> findReviewedLines(
       PatchSet.Id psId, Account.Id accountId, String path);
+
+  /**
+   * Finds all reviewed lines/regions for the given patch set and file across all users.
+   *
+   * @param psId patch set ID
+   * @param path file path to filter by (required)
+   * @return map of account ID to list of reviewed lines/regions for that account
+   */
+  default ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> findAllReviewedLines(
+      PatchSet.Id psId, String path) {
+    throw new NotImplementedException(
+        "findAllReviewedLines() is not implemented for this AccountPatchLineReviewStore.");
+  }
 }

--- a/java/com/google/gerrit/server/restapi/change/ChangeRestApiModule.java
+++ b/java/com/google/gerrit/server/restapi/change/ChangeRestApiModule.java
@@ -161,6 +161,7 @@ public class ChangeRestApiModule extends RestApiModule {
     get(FILE_KIND, "reviewed_lines").to(ReviewedLines.GetReviewedLines.class);
     put(FILE_KIND, "reviewed_lines").to(ReviewedLines.PutReviewedLine.class);
     delete(FILE_KIND, "reviewed_lines").to(ReviewedLines.DeleteReviewedLine.class);
+    get(FILE_KIND, "all_reviewed_lines").to(ReviewedLines.GetAllReviewedLines.class);
 
     child(REVISION_KIND, "fixes").to(Fixes.class);
     post(FIX_KIND, "apply").to(ApplyStoredFix.class);

--- a/java/com/google/gerrit/server/restapi/change/ReviewedLines.java
+++ b/java/com/google/gerrit/server/restapi/change/ReviewedLines.java
@@ -14,6 +14,9 @@
 
 package com.google.gerrit.server.restapi.change;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gerrit.entities.Account;
 import com.google.gerrit.extensions.common.LineReviewedInfo;
 import com.google.gerrit.extensions.restapi.BadRequestException;
 import com.google.gerrit.extensions.restapi.Response;
@@ -25,7 +28,9 @@ import com.google.gerrit.server.plugincontext.PluginItemContext;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /** REST API for line-level and region-level reviewed flags within a file. */
@@ -72,6 +77,49 @@ public class ReviewedLines {
             }
           });
       return Response.ok(infos);
+    }
+  }
+
+  @Singleton
+  public static class GetAllReviewedLines implements RestReadView<FileResource> {
+    private final PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore;
+
+    @Inject
+    GetAllReviewedLines(PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore) {
+      this.accountPatchLineReviewStore = accountPatchLineReviewStore;
+    }
+
+    @Override
+    public Response<Map<Integer, List<LineReviewedInfo>>> apply(FileResource resource) {
+      ImmutableMap<Account.Id, ImmutableList<AccountPatchLineReviewStore.ReviewedLine>> byAccount =
+          accountPatchLineReviewStore.call(
+              s ->
+                  s.findAllReviewedLines(
+                      resource.getPatchKey().patchSetId(),
+                      resource.getPatchKey().fileName()));
+
+      Map<Integer, List<LineReviewedInfo>> result = new LinkedHashMap<>();
+      byAccount.forEach(
+          (accountId, lines) -> {
+            List<LineReviewedInfo> infos = new ArrayList<>();
+            for (AccountPatchLineReviewStore.ReviewedLine line : lines) {
+              LineReviewedInfo info = new LineReviewedInfo();
+              info.line = line.lineNumber();
+              info.side = line.getSide();
+              if (line.startLine() != line.endLine()
+                  || line.startChar() != 0
+                  || line.endChar() != 0) {
+                info.range = new com.google.gerrit.extensions.client.Comment.Range();
+                info.range.startLine = line.startLine();
+                info.range.startCharacter = line.startChar();
+                info.range.endLine = line.endLine();
+                info.range.endCharacter = line.endChar();
+              }
+              infos.add(info);
+            }
+            result.put(accountId.get(), infos);
+          });
+      return Response.ok(result);
     }
   }
 

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -18,6 +18,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.FluentLogger;
 import com.google.common.primitives.Ints;
 import com.google.gerrit.entities.Account;
@@ -45,6 +46,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import javax.sql.DataSource;
@@ -453,6 +456,50 @@ public abstract class JdbcAccountPatchLineReviewStore
           }
           return Optional.of(PatchSetWithReviewedLines.create(psId, lines));
         }
+      }
+    } catch (SQLException e) {
+      throw convertError("select", e);
+    }
+  }
+
+  @Override
+  public ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> findAllReviewedLines(
+      PatchSet.Id psId, String path) {
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "Find all reviewers' line reviewed flags",
+                Metadata.builder().patchSetId(psId.get()).filePath(path).build());
+        Connection con = ds.getConnection();
+        PreparedStatement stmt =
+            con.prepareStatement(
+                "SELECT account_id, file_name, line_number, side, start_line, start_char, "
+                    + "end_line, end_char "
+                    + "FROM account_patch_line_reviews "
+                    + "WHERE change_id = ? AND patch_set_id = ? AND file_name = ? "
+                    + "ORDER BY account_id, line_number")) {
+      stmt.setInt(1, psId.changeId().get());
+      stmt.setInt(2, psId.get());
+      stmt.setString(3, path);
+      try (ResultSet rs = stmt.executeQuery()) {
+        Map<Account.Id, ImmutableList.Builder<ReviewedLine>> builders = new LinkedHashMap<>();
+        while (rs.next()) {
+          Account.Id accountId = Account.id(rs.getInt("account_id"));
+          builders
+              .computeIfAbsent(accountId, k -> ImmutableList.builder())
+              .add(
+                  ReviewedLine.create(
+                      rs.getString("file_name"),
+                      rs.getInt("line_number"),
+                      rs.getShort("side"),
+                      rs.getInt("start_line"),
+                      rs.getInt("start_char"),
+                      rs.getInt("end_line"),
+                      rs.getInt("end_char")));
+        }
+        ImmutableMap.Builder<Account.Id, ImmutableList<ReviewedLine>> result =
+            ImmutableMap.builder();
+        builders.forEach((accountId, builder) -> result.put(accountId, builder.build()));
+        return result.build();
       }
     } catch (SQLException e) {
       throw convertError("select", e);

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -58,6 +58,15 @@ public abstract class JdbcAccountPatchLineReviewStore
     implements AccountPatchLineReviewStore, LifecycleListener {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
+  private static final String COL_ACCOUNT_ID = "account_id";
+  private static final String COL_FILE_NAME = "file_name";
+  private static final String COL_LINE_NUMBER = "line_number";
+  private static final String COL_SIDE = "side";
+  private static final String COL_START_LINE = "start_line";
+  private static final String COL_START_CHAR = "start_char";
+  private static final String COL_END_LINE = "end_line";
+  private static final String COL_END_CHAR = "end_char";
+
   @VisibleForTesting
   public static final String TEST_IN_MEMORY_URL =
       "jdbc:h2:mem:account_patch_line_reviews;DB_CLOSE_DELAY=-1";
@@ -442,13 +451,13 @@ public abstract class JdbcAccountPatchLineReviewStore
           while (rs.next()) {
             builder.add(
                 ReviewedLine.create(
-                    rs.getString("file_name"),
-                    rs.getInt("line_number"),
-                    rs.getShort("side"),
-                    rs.getInt("start_line"),
-                    rs.getInt("start_char"),
-                    rs.getInt("end_line"),
-                    rs.getInt("end_char")));
+                    rs.getString(COL_FILE_NAME),
+                    rs.getInt(COL_LINE_NUMBER),
+                    rs.getShort(COL_SIDE),
+                    rs.getInt(COL_START_LINE),
+                    rs.getInt(COL_START_CHAR),
+                    rs.getInt(COL_END_LINE),
+                    rs.getInt(COL_END_CHAR)));
           }
           ImmutableList<ReviewedLine> lines = builder.build();
           if (lines.isEmpty()) {
@@ -483,18 +492,18 @@ public abstract class JdbcAccountPatchLineReviewStore
       try (ResultSet rs = stmt.executeQuery()) {
         Map<Account.Id, ImmutableList.Builder<ReviewedLine>> builders = new LinkedHashMap<>();
         while (rs.next()) {
-          Account.Id accountId = Account.id(rs.getInt("account_id"));
+          Account.Id accountId = Account.id(rs.getInt(COL_ACCOUNT_ID));
           builders
               .computeIfAbsent(accountId, k -> ImmutableList.builder())
               .add(
                   ReviewedLine.create(
-                      rs.getString("file_name"),
-                      rs.getInt("line_number"),
-                      rs.getShort("side"),
-                      rs.getInt("start_line"),
-                      rs.getInt("start_char"),
-                      rs.getInt("end_line"),
-                      rs.getInt("end_char")));
+                      rs.getString(COL_FILE_NAME),
+                      rs.getInt(COL_LINE_NUMBER),
+                      rs.getShort(COL_SIDE),
+                      rs.getInt(COL_START_LINE),
+                      rs.getInt(COL_START_CHAR),
+                      rs.getInt(COL_END_LINE),
+                      rs.getInt(COL_END_CHAR)));
         }
         ImmutableMap.Builder<Account.Id, ImmutableList<ReviewedLine>> result =
             ImmutableMap.builder();

--- a/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
@@ -16,6 +16,7 @@ package com.google.gerrit.testing;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
@@ -29,7 +30,9 @@ import com.google.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -214,6 +217,34 @@ public class FakeAccountPatchLineReviewStore
         }
       }
       store.removeAll(toRemove);
+    }
+  }
+
+  @Override
+  public ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> findAllReviewedLines(
+      PatchSet.Id psId, String path) {
+    synchronized (store) {
+      Map<Account.Id, ImmutableList.Builder<ReviewedLine>> builders = new LinkedHashMap<>();
+      for (LineEntity entity : store) {
+        if (!entity.psId().equals(psId) || !entity.path().equals(path)) {
+          continue;
+        }
+        builders
+            .computeIfAbsent(entity.accountId(), k -> ImmutableList.builder())
+            .add(
+                ReviewedLine.create(
+                    entity.path(),
+                    entity.lineNumber(),
+                    entity.side(),
+                    entity.startLine(),
+                    entity.startChar(),
+                    entity.endLine(),
+                    entity.endChar()));
+      }
+      ImmutableMap.Builder<Account.Id, ImmutableList<ReviewedLine>> result =
+          ImmutableMap.builder();
+      builders.forEach((accountId, builder) -> result.put(accountId, builder.build()));
+      return result.build();
     }
   }
 

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -1853,6 +1853,119 @@ public class RevisionIT extends AbstractDaemonTest {
     adminRestSession.delete(reviewedLinesUrl(r.getChangeId())).assertBadRequest();
   }
 
+  // -- HTTP-level tests for the all_reviewed_lines REST endpoint --
+
+  private String allReviewedLinesUrl(String changeId) {
+    return "/changes/"
+        + changeId
+        + "/revisions/current/files/"
+        + FILE_NAME
+        + "/all_reviewed_lines";
+  }
+
+  @Test
+  public void getAllReviewedLines_noMarkers_returnsEmptyMap() throws Exception {
+    PushOneCommit.Result r = createChange();
+
+    RestResponse resp = adminRestSession.get(allReviewedLinesUrl(r.getChangeId()));
+    resp.assertOK();
+    Map<Integer, List<LineReviewedInfo>> result =
+        newGson()
+            .fromJson(
+                resp.getReader(),
+                new TypeToken<Map<Integer, List<LineReviewedInfo>>>() {}.getType());
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void getAllReviewedLines_singleReviewer_returnsMarkersUnderAccountId() throws Exception {
+    PushOneCommit.Result r = createChange();
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 5;
+    input.side = Side.REVISION;
+    adminRestSession.put(reviewedLinesUrl(r.getChangeId()), input).assertCreated();
+
+    RestResponse resp = adminRestSession.get(allReviewedLinesUrl(r.getChangeId()));
+    resp.assertOK();
+    Map<Integer, List<LineReviewedInfo>> result =
+        newGson()
+            .fromJson(
+                resp.getReader(),
+                new TypeToken<Map<Integer, List<LineReviewedInfo>>>() {}.getType());
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey(admin.id().get());
+    List<LineReviewedInfo> adminLines = result.get(admin.id().get());
+    assertThat(adminLines).hasSize(1);
+    assertThat(adminLines.get(0).line).isEqualTo(5);
+    assertThat(adminLines.get(0).side).isEqualTo(Side.REVISION);
+  }
+
+  @Test
+  public void getAllReviewedLines_multipleReviewers_returnsAllMarkers() throws Exception {
+    PushOneCommit.Result r = createChange();
+
+    // Admin marks line 5
+    LineReviewedInput adminInput = new LineReviewedInput();
+    adminInput.line = 5;
+    adminInput.side = Side.REVISION;
+    adminRestSession.put(reviewedLinesUrl(r.getChangeId()), adminInput).assertCreated();
+
+    // User marks line 10
+    LineReviewedInput userInput = new LineReviewedInput();
+    userInput.line = 10;
+    userInput.side = Side.REVISION;
+    userRestSession.put(reviewedLinesUrl(r.getChangeId()), userInput).assertCreated();
+
+    RestResponse resp = adminRestSession.get(allReviewedLinesUrl(r.getChangeId()));
+    resp.assertOK();
+    Map<Integer, List<LineReviewedInfo>> result =
+        newGson()
+            .fromJson(
+                resp.getReader(),
+                new TypeToken<Map<Integer, List<LineReviewedInfo>>>() {}.getType());
+
+    assertThat(result).hasSize(2);
+    assertThat(result).containsKey(admin.id().get());
+    assertThat(result).containsKey(user.id().get());
+    assertThat(result.get(admin.id().get()).get(0).line).isEqualTo(5);
+    assertThat(result.get(user.id().get()).get(0).line).isEqualTo(10);
+  }
+
+  @Test
+  public void getAllReviewedLines_markersOnOtherFile_notIncluded() throws Exception {
+    // Create a change with two files
+    PushOneCommit push =
+        pushFactory.create(
+            admin.newIdent(),
+            testRepo,
+            "Subject",
+            ImmutableMap.of(FILE_NAME, "content", "other.txt", "other content"));
+    PushOneCommit.Result r = push.to("refs/for/master");
+
+    // Admin marks a line in FILE_NAME
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 1;
+    input.side = Side.REVISION;
+    adminRestSession.put(reviewedLinesUrl(r.getChangeId()), input).assertCreated();
+
+    // Query all_reviewed_lines for the other file — should be empty
+    String otherFileUrl =
+        "/changes/"
+            + r.getChangeId()
+            + "/revisions/current/files/other.txt/all_reviewed_lines";
+    RestResponse resp = adminRestSession.get(otherFileUrl);
+    resp.assertOK();
+    Map<Integer, List<LineReviewedInfo>> result =
+        newGson()
+            .fromJson(
+                resp.getReader(),
+                new TypeToken<Map<Integer, List<LineReviewedInfo>>>() {}.getType());
+
+    assertThat(result).isEmpty();
+  }
+
   @Test
   public void setReviewedFlagWithMultiplePatchSets() throws Exception {
     PushOneCommit push = pushFactory.create(admin.newIdent(), testRepo);

--- a/javatests/com/google/gerrit/acceptance/rest/binding/ChangesRestApiBindingsIT.java
+++ b/javatests/com/google/gerrit/acceptance/rest/binding/ChangesRestApiBindingsIT.java
@@ -220,7 +220,8 @@ public class ChangesRestApiBindingsIT extends AbstractDaemonTest {
           RestCall.delete("/changes/%s/revisions/%s/files/%s/reviewed"),
           RestCall.get("/changes/%s/revisions/%s/files/%s/reviewed_lines"),
           RestCall.put("/changes/%s/revisions/%s/files/%s/reviewed_lines"),
-          RestCall.delete("/changes/%s/revisions/%s/files/%s/reviewed_lines"));
+          RestCall.delete("/changes/%s/revisions/%s/files/%s/reviewed_lines"),
+          RestCall.get("/changes/%s/revisions/%s/files/%s/all_reviewed_lines"));
 
   /**
    * Change message REST endpoints to be tested, each URL contains placeholders for the change

--- a/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
+++ b/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
@@ -16,6 +16,8 @@ package com.google.gerrit.server.schema;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
@@ -225,5 +227,76 @@ public class JdbcAccountPatchLineReviewStoreTest {
 
     assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A)).isEmpty();
     assertThat(store.findReviewedLines(PS_1, ACCOUNT_2, FILE_A)).isPresent();
+  }
+
+  // -- tests for findAllReviewedLines --
+
+  @Test
+  public void findAllReviewedLines_noMarkers_returnsEmptyMap() {
+    ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> result =
+        store.findAllReviewedLines(PS_1, FILE_A);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void findAllReviewedLines_singleAccount_returnsLines() {
+    var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(3));
+    var unused2 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(7));
+
+    ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> result =
+        store.findAllReviewedLines(PS_1, FILE_A);
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey(ACCOUNT_1);
+    assertThat(result.get(ACCOUNT_1)).hasSize(2);
+    assertThat(result.get(ACCOUNT_1).get(0).lineNumber()).isEqualTo(3);
+    assertThat(result.get(ACCOUNT_1).get(1).lineNumber()).isEqualTo(7);
+  }
+
+  @Test
+  public void findAllReviewedLines_multipleAccounts_groupedByAccount() {
+    var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+    var unused2 = store.markLineReviewed(PS_1, ACCOUNT_2, FILE_A, lineInput(5));
+    var unused3 = store.markLineReviewed(PS_1, ACCOUNT_2, FILE_A, lineInput(10));
+
+    ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> result =
+        store.findAllReviewedLines(PS_1, FILE_A);
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(ACCOUNT_1)).hasSize(1);
+    assertThat(result.get(ACCOUNT_1).get(0).lineNumber()).isEqualTo(1);
+    assertThat(result.get(ACCOUNT_2)).hasSize(2);
+    assertThat(result.get(ACCOUNT_2).get(0).lineNumber()).isEqualTo(5);
+    assertThat(result.get(ACCOUNT_2).get(1).lineNumber()).isEqualTo(10);
+  }
+
+  @Test
+  public void findAllReviewedLines_isolatedByFile() {
+    var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+    var unused2 = store.markLineReviewed(PS_1, ACCOUNT_2, FILE_B, lineInput(2));
+
+    ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> resultA =
+        store.findAllReviewedLines(PS_1, FILE_A);
+    ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> resultB =
+        store.findAllReviewedLines(PS_1, FILE_B);
+
+    assertThat(resultA).hasSize(1);
+    assertThat(resultA).containsKey(ACCOUNT_1);
+    assertThat(resultB).hasSize(1);
+    assertThat(resultB).containsKey(ACCOUNT_2);
+  }
+
+  @Test
+  public void findAllReviewedLines_isolatedByPatchSet() {
+    var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+    var unused2 = store.markLineReviewed(PS_2, ACCOUNT_2, FILE_A, lineInput(2));
+
+    ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> result =
+        store.findAllReviewedLines(PS_1, FILE_A);
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey(ACCOUNT_1);
+    assertThat(result).doesNotContainKey(ACCOUNT_2);
   }
 }


### PR DESCRIPTION
Fixes #10 
- Add `findAllReviewedLines` to AccountPathLineReviewStore and implement in JdbcAccountPatchLineReviewStore
- Create `GetAllReviewedLine` REST handler
- Register GET all_reviewed_lines in ChangeRestApiModule
- Create store unit tests in JdbcAccountPatchLineReviewStoreTest
- Write HTTP integration tests

Change-Id: I2285a18b065d95b6dd3deaa3377df3266132b0ab