### PR TITLE
Add backend functionality for propagation of review markers across patch sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Install tools/node_tools dependencies
         run: cd tools/node_tools && yarn install --frozen-lockfile
 
+      # Materialize polygerrit-ui/app/node_modules so @ui_npm matches CI and developer machines, and
+      # lockfile issues fail before a long Bazel analysis.
+      - name: Install polygerrit-ui/app dependencies
+        run: cd polygerrit-ui/app && yarn install --frozen-lockfile
+
       - name: Install Bazelisk
         run: |
           mkdir -p "$HOME/.local/bin"

--- a/java/com/google/gerrit/extensions/api/changes/LineReviewedInput.java
+++ b/java/com/google/gerrit/extensions/api/changes/LineReviewedInput.java
@@ -36,6 +36,10 @@ public class LineReviewedInput {
 
   /**
    * Review status of the line or region.
+   *
+   * <p>Clients should send {@link ReviewStatus#READ} when marking reviewed. Server-side
+   * propagation may later surface {@link ReviewStatus#TENTATIVELY_READ} for unchanged carryover in
+   * newer patch sets.
    */
   public ReviewStatus status;
 }

--- a/java/com/google/gerrit/extensions/api/changes/LineReviewedInput.java
+++ b/java/com/google/gerrit/extensions/api/changes/LineReviewedInput.java
@@ -15,6 +15,7 @@
 package com.google.gerrit.extensions.api.changes;
 
 import com.google.gerrit.extensions.client.Comment.Range;
+import com.google.gerrit.extensions.client.ReviewStatus;
 import com.google.gerrit.extensions.client.Side;
 
 /**
@@ -32,4 +33,9 @@ public class LineReviewedInput {
 
   /** Side of the diff: PARENT (0) or REVISION (1). Default is REVISION. */
   public Side side;
+
+  /**
+   * Review status of the line or region.
+   */
+  public ReviewStatus status;
 }

--- a/java/com/google/gerrit/extensions/client/ReviewStatus.java
+++ b/java/com/google/gerrit/extensions/client/ReviewStatus.java
@@ -31,5 +31,23 @@ public enum ReviewStatus {
   TENTATIVELY_READ,
 
   /** The region is not read for this reviewer on this patch set. */
-  UNREAD,
+  UNREAD;
+
+  /**
+   * Value persisted in {@code account_patch_line_reviews.review_status}. Only {@link #READ} and
+   * {@link #TENTATIVELY_READ} are stored; {@link #UNREAD} is represented by absence of a row.
+   */
+  public short toDbValue() {
+    return (short) ordinal();
+  }
+
+  /** Inverse of {@link #toDbValue()} for rows in {@code account_patch_line_reviews}. */
+  public static ReviewStatus fromDbValue(short value) {
+    for (ReviewStatus s : values()) {
+      if (s.ordinal() == value) {
+        return s;
+      }
+    }
+    return READ;
+  }
 }

--- a/java/com/google/gerrit/extensions/client/ReviewStatus.java
+++ b/java/com/google/gerrit/extensions/client/ReviewStatus.java
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.client;
+
+/**
+ * Review status of a line or region for a patch set.
+ *
+ * <p>Clients submit {@link #READ} when marking a region; {@link
+ * #TENTATIVELY_READ} is default for lines/regions that are unchanged since previous commit, otherwise default is {@link #UNREAD}.
+ */
+public enum ReviewStatus {
+  /** The reviewer explicitly marked this region as read on this patch set. */
+  READ,
+
+  /**
+   * The server carried progress forward from an earlier patch set because the content in this
+   * region is unchanged; the reviewer should confirm before treating it as fully read.
+   */
+  TENTATIVELY_READ,
+
+  /** The region is not read for this reviewer on this patch set. */
+  UNREAD,
+}

--- a/java/com/google/gerrit/extensions/common/LineReviewedInfo.java
+++ b/java/com/google/gerrit/extensions/common/LineReviewedInfo.java
@@ -35,7 +35,10 @@ public class LineReviewedInfo {
   public Side side;
 
   /**
-   * Review status of the line or region. 
+   * Review status of the line or region.
+   *
+   * <p>Returned as READ for explicit review actions and TENTATIVELY_READ for propagated carryover
+   * from unchanged regions in prior patch sets.
    */
   public ReviewStatus status;
 }

--- a/java/com/google/gerrit/extensions/common/LineReviewedInfo.java
+++ b/java/com/google/gerrit/extensions/common/LineReviewedInfo.java
@@ -15,6 +15,7 @@
 package com.google.gerrit.extensions.common;
 
 import com.google.gerrit.extensions.client.Comment.Range;
+import com.google.gerrit.extensions.client.ReviewStatus;
 import com.google.gerrit.extensions.client.Side;
 
 /**
@@ -32,4 +33,9 @@ public class LineReviewedInfo {
 
   /** Side of the diff: PARENT (0) or REVISION (1). Default is REVISION. */
   public Side side;
+
+  /**
+   * Review status of the line or region. 
+   */
+  public ReviewStatus status;
 }

--- a/java/com/google/gerrit/pgm/util/BatchProgramModule.java
+++ b/java/com/google/gerrit/pgm/util/BatchProgramModule.java
@@ -151,7 +151,8 @@ public class BatchProgramModule extends FactoryModule {
     // We're just running through each change
     // once, so don't worry about cache removal.
     bind(new TypeLiteral<DynamicSet<CacheRemovalListener>>() {}).toInstance(DynamicSet.emptySet());
-    // Required by PatchSetInserter -> LineReviewPropagation -> PluginItemContext during reindex.
+    // Required by PatchSetInserter/ReplaceOp -> LineReviewPropagation -> PluginItemContext during
+    // reindex; propagation is a no-op if no AccountPatchLineReviewStore implementation is bound.
     DynamicItem.itemOf(binder(), AccountPatchLineReviewStore.class);
     DynamicMap.mapOf(binder(), new TypeLiteral<Cache<?, ?>>() {});
     bind(new TypeLiteral<List<CommentLinkInfo>>() {})

--- a/java/com/google/gerrit/pgm/util/BatchProgramModule.java
+++ b/java/com/google/gerrit/pgm/util/BatchProgramModule.java
@@ -25,6 +25,7 @@ import com.google.gerrit.entities.SubmitRequirement;
 import com.google.gerrit.extensions.api.projects.CommentLinkInfo;
 import com.google.gerrit.extensions.common.AccountVisibility;
 import com.google.gerrit.extensions.config.FactoryModule;
+import com.google.gerrit.extensions.registration.DynamicItem;
 import com.google.gerrit.extensions.registration.DynamicMap;
 import com.google.gerrit.extensions.registration.DynamicSet;
 import com.google.gerrit.extensions.restapi.RestView;
@@ -47,6 +48,7 @@ import com.google.gerrit.server.cache.CacheRemovalListener;
 import com.google.gerrit.server.cache.h2.CacheOptions;
 import com.google.gerrit.server.cache.h2.H2CacheModule;
 import com.google.gerrit.server.cache.mem.DefaultMemoryCacheModule;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore;
 import com.google.gerrit.server.change.ChangeJson;
 import com.google.gerrit.server.change.ChangeKindCacheImpl;
 import com.google.gerrit.server.change.EmailNewPatchSet;
@@ -149,6 +151,8 @@ public class BatchProgramModule extends FactoryModule {
     // We're just running through each change
     // once, so don't worry about cache removal.
     bind(new TypeLiteral<DynamicSet<CacheRemovalListener>>() {}).toInstance(DynamicSet.emptySet());
+    // Required by PatchSetInserter -> LineReviewPropagation -> PluginItemContext during reindex.
+    DynamicItem.itemOf(binder(), AccountPatchLineReviewStore.class);
     DynamicMap.mapOf(binder(), new TypeLiteral<Cache<?, ?>>() {});
     bind(new TypeLiteral<List<CommentLinkInfo>>() {})
         .toProvider(CommentLinkProvider.class)

--- a/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
@@ -178,7 +178,8 @@ public interface AccountPatchLineReviewStore {
 
   /**
    * Inserts {@link ReviewStatus#TENTATIVELY_READ} rows with {@code tentative_carryover = true} for
-   * markers carried from a prior patch set. Skips a row if the primary key already exists.
+   * markers carried from a prior patch set by {@link LineReviewPropagation}. Skips a row if the
+   * primary key already exists.
    *
    * @param psId new patch set ID
    * @param accountId account ID

--- a/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
@@ -16,6 +16,7 @@ package com.google.gerrit.server.change;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
@@ -164,4 +165,29 @@ public interface AccountPatchLineReviewStore {
    */
   Optional<PatchSetWithReviewedLines> findReviewedLines(
       PatchSet.Id psId, Account.Id accountId, String path);
+
+  /**
+   * Accounts that have at least one line review row stored for the given patch set.
+   *
+   * @param psId patch set ID
+   */
+  default ImmutableSet<Account.Id> accountsWithLineReviews(PatchSet.Id psId) {
+    throw new NotImplementedException(
+        "accountsWithLineReviews() is not implemented for this AccountPatchLineReviewStore.");
+  }
+
+  /**
+   * Inserts {@link ReviewStatus#TENTATIVELY_READ} rows with {@code tentative_carryover = true} for
+   * markers carried from a prior patch set. Skips a row if the primary key already exists.
+   *
+   * @param psId new patch set ID
+   * @param accountId account ID
+   * @param lines geometry and side for each marker; {@link ReviewedLine#reviewStatus()} is ignored
+   */
+  default void insertPropagatedTentativeReviews(
+      PatchSet.Id psId, Account.Id accountId, Collection<ReviewedLine> lines) {
+    throw new NotImplementedException(
+        "insertPropagatedTentativeReviews() is not implemented for this"
+            + " AccountPatchLineReviewStore.");
+  }
 }

--- a/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
@@ -20,7 +20,7 @@ import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
 import com.google.gerrit.extensions.api.changes.LineReviewedInput;
-import com.google.gerrit.extensions.client.Comment.Range;
+import com.google.gerrit.extensions.client.ReviewStatus;
 import com.google.gerrit.extensions.client.Side;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import java.util.Collection;
@@ -58,6 +58,9 @@ public interface AccountPatchLineReviewStore {
 
     public abstract int endChar();
 
+    /** Stored status; {@link ReviewStatus#UNREAD} does not appear. */
+    public abstract ReviewStatus reviewStatus();
+
     public static ReviewedLine create(
         String path,
         int lineNumber,
@@ -65,9 +68,10 @@ public interface AccountPatchLineReviewStore {
         int startLine,
         int startChar,
         int endLine,
-        int endChar) {
+        int endChar,
+        ReviewStatus reviewStatus) {
       return new AutoValue_AccountPatchLineReviewStore_ReviewedLine(
-          path, lineNumber, side, startLine, startChar, endLine, endChar);
+          path, lineNumber, side, startLine, startChar, endLine, endChar, reviewStatus);
     }
 
     public Side getSide() {

--- a/java/com/google/gerrit/server/change/LineReviewPropagation.java
+++ b/java/com/google/gerrit/server/change/LineReviewPropagation.java
@@ -1,0 +1,263 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.change;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.flogger.FluentLogger;
+import com.google.gerrit.common.Nullable;
+import com.google.gerrit.entities.Change;
+import com.google.gerrit.entities.PatchSet;
+import com.google.gerrit.extensions.client.ReviewStatus;
+import com.google.gerrit.server.CommentsUtil;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.ReviewedLine;
+import com.google.gerrit.server.patch.DiffMappings;
+import com.google.gerrit.server.patch.DiffNotAvailableException;
+import com.google.gerrit.server.patch.DiffOperations;
+import com.google.gerrit.server.patch.DiffOptions;
+import com.google.gerrit.server.patch.GitPositionTransformer;
+import com.google.gerrit.server.patch.GitPositionTransformer.BestPositionOnConflict;
+import com.google.gerrit.server.patch.GitPositionTransformer.Mapping;
+import com.google.gerrit.server.patch.GitPositionTransformer.Position;
+import com.google.gerrit.server.patch.GitPositionTransformer.PositionedEntity;
+import com.google.gerrit.server.patch.filediff.FileDiffOutput;
+import com.google.gerrit.server.patch.filediff.FileEdits;
+import com.google.gerrit.server.patch.filediff.TaggedEdit;
+import com.google.gerrit.server.plugincontext.PluginItemContext;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.eclipse.jgit.lib.ObjectId;
+
+/**
+ * Carries line-review markers from a prior patch set to a new patch set for regions that still exist
+ * in the revision tree, using the same diff-based position mapping as comment porting.
+ *
+ * <p>Only the revision side of the diff (side {@code 1}) is propagated for now.
+ */
+@Singleton
+public class LineReviewPropagation {
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  private final PluginItemContext<AccountPatchLineReviewStore> lineReviewStore;
+  private final DiffOperations diffOperations;
+  private final CommentsUtil commentsUtil;
+  private final GitPositionTransformer positionTransformer =
+      new GitPositionTransformer(BestPositionOnConflict.INSTANCE);
+
+  @Inject
+  LineReviewPropagation(
+      PluginItemContext<AccountPatchLineReviewStore> lineReviewStore,
+      DiffOperations diffOperations,
+      CommentsUtil commentsUtil) {
+    this.lineReviewStore = lineReviewStore;
+    this.diffOperations = diffOperations;
+    this.commentsUtil = commentsUtil;
+  }
+
+  /**
+   * Propagates markers from {@code priorPatchSet} onto {@code newPatchSet} for all accounts. No-op
+   * if the line-review store is not configured.
+   */
+  public void propagateOnNewPatchSet(
+      Change change, PatchSet priorPatchSet, PatchSet newPatchSet) {
+    lineReviewStore.run(
+        store -> {
+          try {
+            propagate(store, change, priorPatchSet, newPatchSet);
+          } catch (Exception e) {
+            logger.atWarning().withCause(e).log(
+                "Failed to propagate line reviews from patch set %s to %s on change %s",
+                priorPatchSet.number(),
+                newPatchSet.number(),
+                change.getId());
+          }
+        });
+  }
+
+  @VisibleForTesting
+  void propagate(
+      AccountPatchLineReviewStore store,
+      Change change,
+      PatchSet priorPatchSet,
+      PatchSet newPatchSet)
+      throws DiffNotAvailableException {
+    if (!priorPatchSet.id().changeId().equals(newPatchSet.id().changeId())) {
+      return;
+    }
+    PatchSet.Id priorId = priorPatchSet.id();
+    PatchSet.Id newId = newPatchSet.id();
+    short revisionSide = 1;
+
+    ObjectId oldCommit =
+        commentsUtil
+            .determineCommitId(change, priorPatchSet, revisionSide)
+            .orElse(ObjectId.zeroId());
+    ObjectId newCommit =
+        commentsUtil
+            .determineCommitId(change, newPatchSet, revisionSide)
+            .orElse(ObjectId.zeroId());
+    if (ObjectId.zeroId().equals(oldCommit) || ObjectId.zeroId().equals(newCommit)) {
+      return;
+    }
+
+    ImmutableSet<Mapping> mappings = loadCommitMappings(change.getProject(), oldCommit, newCommit);
+
+    for (com.google.gerrit.entities.Account.Id accountId : store.accountsWithLineReviews(priorId)) {
+      Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> priorLines =
+          store.findReviewedLines(priorId, accountId, null);
+      if (priorLines.isEmpty()) {
+        continue;
+      }
+      ImmutableList<ReviewedLine> revisionLines =
+          priorLines.get().lines().stream()
+              .filter(l -> l.side() == revisionSide)
+              .filter(l -> l.reviewStatus() != ReviewStatus.UNREAD)
+              .collect(toImmutableList());
+      if (revisionLines.isEmpty()) {
+        continue;
+      }
+
+      ImmutableList<PositionedEntity<ReviewedLine>> positioned =
+          revisionLines.stream().map(this::toPositionedEntity).collect(toImmutableList());
+      ImmutableSet<ReviewedLine> propagated =
+          positionTransformer.transform(positioned, mappings).stream()
+              .map(PositionedEntity::getEntityAtUpdatedPosition)
+              .filter(Objects::nonNull)
+              .collect(toImmutableSet());
+
+      if (!propagated.isEmpty()) {
+        store.insertPropagatedTentativeReviews(newId, accountId, dedupe(propagated));
+      }
+    }
+  }
+
+  private ImmutableList<ReviewedLine> dedupe(ImmutableSet<ReviewedLine> lines) {
+    Set<String> seen = new HashSet<>();
+    ImmutableList.Builder<ReviewedLine> b = ImmutableList.builder();
+    for (ReviewedLine l : lines) {
+      String key =
+          l.path()
+              + "\0"
+              + l.lineNumber()
+              + "\0"
+              + l.side()
+              + "\0"
+              + l.startLine()
+              + "\0"
+              + l.startChar()
+              + "\0"
+              + l.endLine()
+              + "\0"
+              + l.endChar();
+      if (seen.add(key)) {
+        b.add(l);
+      }
+    }
+    return b.build();
+  }
+
+  private ImmutableSet<Mapping> loadCommitMappings(
+      com.google.gerrit.entities.Project.NameKey project, ObjectId from, ObjectId to)
+      throws DiffNotAvailableException {
+    Map<String, FileDiffOutput> modifiedFiles =
+        diffOperations.listModifiedFiles(
+            project,
+            from,
+            to,
+            DiffOptions.builder().skipFilesWithAllEditsDueToRebase(false).build());
+    return modifiedFiles.values().stream()
+        .map(LineReviewPropagation::getFileEdits)
+        .map(DiffMappings::toMapping)
+        .collect(toImmutableSet());
+  }
+
+  private static FileEdits getFileEdits(FileDiffOutput fileDiffOutput) {
+    return FileEdits.create(
+        fileDiffOutput.edits().stream().map(TaggedEdit::edit).collect(toImmutableList()),
+        fileDiffOutput.oldPath(),
+        fileDiffOutput.newPath());
+  }
+
+  private PositionedEntity<ReviewedLine> toPositionedEntity(ReviewedLine line) {
+    return PositionedEntity.create(
+        line,
+        LineReviewPropagation::extractPosition,
+        LineReviewPropagation::createReviewedLineAtNewPosition);
+  }
+
+  private static Position extractPosition(ReviewedLine line) {
+    Position.Builder positionBuilder = Position.builder();
+    positionBuilder.filePath(line.path());
+    extractLineRange(line).ifPresent(positionBuilder::lineRange);
+    return positionBuilder.build();
+  }
+
+  /**
+   * Line specifications are 1-based in {@link ReviewedLine}; {@link Position} uses 0-based {@link
+   * GitPositionTransformer.Range} with an exclusive end line, matching {@code CommentPorter}.
+   */
+  private static Optional<GitPositionTransformer.Range> extractLineRange(ReviewedLine line) {
+    boolean hasExplicitRange =
+        line.startLine() != line.lineNumber()
+            || line.endLine() != line.lineNumber()
+            || line.startChar() > 0
+            || line.endChar() > 0;
+    if (hasExplicitRange) {
+      int exclusiveEndLine =
+          line.endChar() > 0 ? line.endLine() : line.endLine() - 1;
+      return Optional.of(
+          GitPositionTransformer.Range.create(line.startLine() - 1, exclusiveEndLine));
+    }
+    return Optional.of(
+        GitPositionTransformer.Range.create(line.lineNumber() - 1, line.lineNumber()));
+  }
+
+  @Nullable
+  private static ReviewedLine createReviewedLineAtNewPosition(
+      ReviewedLine orig, Position newPosition) {
+    if (!newPosition.filePath().isPresent() || !newPosition.lineRange().isPresent()) {
+      return null;
+    }
+    String path = newPosition.filePath().get();
+    GitPositionTransformer.Range lr = newPosition.lineRange().get();
+    short side = orig.side();
+    boolean hasCharRange = orig.startChar() > 0 || orig.endChar() > 0;
+    boolean multiLine = orig.startLine() != orig.endLine();
+    if (hasCharRange || multiLine) {
+      int adjustedEndLine = orig.endChar() > 0 ? lr.end() : lr.end() + 1;
+      return ReviewedLine.create(
+          path,
+          adjustedEndLine,
+          side,
+          lr.start() + 1,
+          orig.startChar(),
+          adjustedEndLine,
+          orig.endChar(),
+          ReviewStatus.TENTATIVELY_READ);
+    }
+    int line1 = lr.start() + 1;
+    return ReviewedLine.create(
+        path, line1, side, line1, 0, line1, 0, ReviewStatus.TENTATIVELY_READ);
+  }
+}

--- a/java/com/google/gerrit/server/change/LineReviewPropagation.java
+++ b/java/com/google/gerrit/server/change/LineReviewPropagation.java
@@ -107,6 +107,7 @@ public class LineReviewPropagation {
     }
     PatchSet.Id priorId = priorPatchSet.id();
     PatchSet.Id newId = newPatchSet.id();
+    // Side 1 = REVISION in stored rows; parent-side markers are not ported.
     short revisionSide = 1;
 
     ObjectId oldCommit =
@@ -121,6 +122,7 @@ public class LineReviewPropagation {
       return;
     }
 
+    // One mapping per modified file: line/column shifts from oldCommit to newCommit.
     ImmutableSet<Mapping> mappings = loadCommitMappings(change.getProject(), oldCommit, newCommit);
 
     for (com.google.gerrit.entities.Account.Id accountId : store.accountsWithLineReviews(priorId)) {
@@ -138,6 +140,9 @@ public class LineReviewPropagation {
         continue;
       }
 
+      // Only markers that can be mapped onto unchanged/new positions are carried forward. The
+      // carried rows are stored as TENTATIVELY_READ so users can quickly spot what was likely
+      // already reviewed while still distinguishing it from an explicit READ on this patch set.
       ImmutableList<PositionedEntity<ReviewedLine>> positioned =
           revisionLines.stream().map(this::toPositionedEntity).collect(toImmutableList());
       ImmutableSet<ReviewedLine> propagated =
@@ -147,11 +152,13 @@ public class LineReviewPropagation {
               .collect(toImmutableSet());
 
       if (!propagated.isEmpty()) {
+        // dedupe avoids duplicate inserts from transform overlap.
         store.insertPropagatedTentativeReviews(newId, accountId, dedupe(propagated));
       }
     }
   }
 
+  /** Collapses multiple {@link ReviewedLine} rows that landed on identical geometry after mapping. */
   private ImmutableList<ReviewedLine> dedupe(ImmutableSet<ReviewedLine> lines) {
     Set<String> seen = new HashSet<>();
     ImmutableList.Builder<ReviewedLine> b = ImmutableList.builder();
@@ -177,6 +184,10 @@ public class LineReviewPropagation {
     return b.build();
   }
 
+  /**
+   * Builds position mappings between two revision commits so {@link GitPositionTransformer} can
+   * move each marker from {@code from} to {@code to}.
+   */
   private ImmutableSet<Mapping> loadCommitMappings(
       com.google.gerrit.entities.Project.NameKey project, ObjectId from, ObjectId to)
       throws DiffNotAvailableException {
@@ -192,6 +203,7 @@ public class LineReviewPropagation {
         .collect(toImmutableSet());
   }
 
+  /** Converts unified diff output into the edit list format expected by {@link DiffMappings}. */
   private static FileEdits getFileEdits(FileDiffOutput fileDiffOutput) {
     return FileEdits.create(
         fileDiffOutput.edits().stream().map(TaggedEdit::edit).collect(toImmutableList()),
@@ -199,6 +211,10 @@ public class LineReviewPropagation {
         fileDiffOutput.newPath());
   }
 
+  /**
+   * Wraps a stored marker so the transformer can read its old-file position and materialize a new
+   * {@link ReviewedLine} via {@link #createReviewedLineAtNewPosition}.
+   */
   private PositionedEntity<ReviewedLine> toPositionedEntity(ReviewedLine line) {
     return PositionedEntity.create(
         line,
@@ -206,6 +222,7 @@ public class LineReviewPropagation {
         LineReviewPropagation::createReviewedLineAtNewPosition);
   }
 
+  /** File path plus 0-based line range (see {@link #extractLineRange}) for the transformer. */
   private static Position extractPosition(ReviewedLine line) {
     Position.Builder positionBuilder = Position.builder();
     positionBuilder.filePath(line.path());
@@ -224,15 +241,27 @@ public class LineReviewPropagation {
             || line.startChar() > 0
             || line.endChar() > 0;
     if (hasExplicitRange) {
+      // Multi-line or intra-line character span: map to 0-based half-open [start, end) line range.
+      // When the region ends with characters on the last line, the exclusive end line stays at
+      // endLine; when it ends at end-of-line without trailing chars, the transformer uses one line
+      // less for the exclusive end (matches comment porting).
       int exclusiveEndLine =
           line.endChar() > 0 ? line.endLine() : line.endLine() - 1;
       return Optional.of(
           GitPositionTransformer.Range.create(line.startLine() - 1, exclusiveEndLine));
     }
+    // Single-line point marker: half-open range [line-1, line) in 0-based indices.
     return Optional.of(
         GitPositionTransformer.Range.create(line.lineNumber() - 1, line.lineNumber()));
   }
 
+  /**
+   * Builds the {@link ReviewedLine} row for the new commit after the transformer mapped {@code orig}
+   * to {@code newPosition}.
+   *
+   * <p>Returns {@code null} if the region could not be placed (e.g. deleted hunk); those markers
+   * are dropped rather than stored at a bogus line.
+   */
   @Nullable
   private static ReviewedLine createReviewedLineAtNewPosition(
       ReviewedLine orig, Position newPosition) {
@@ -245,6 +274,12 @@ public class LineReviewPropagation {
     boolean hasCharRange = orig.startChar() > 0 || orig.endChar() > 0;
     boolean multiLine = orig.startLine() != orig.endLine();
     if (hasCharRange || multiLine) {
+      // Geometry: keep the same start/end character columns from the prior patch set so the stored
+      // region still describes a sub-line or multi-line span after mapping. Line numbers come from
+      // the mapped range (lr); adjustedEndLine reconciles 0-based lr.end() with 1-based ReviewedLine
+      // endLine when the original range ended at EOL without trailing characters.
+      //
+      // Status: always TENTATIVELY_READ. 
       int adjustedEndLine = orig.endChar() > 0 ? lr.end() : lr.end() + 1;
       return ReviewedLine.create(
           path,
@@ -256,6 +291,7 @@ public class LineReviewPropagation {
           orig.endChar(),
           ReviewStatus.TENTATIVELY_READ);
     }
+    // Simple single-line marker: anchor line is lr start (1-based); no character span.
     int line1 = lr.start() + 1;
     return ReviewedLine.create(
         path, line1, side, line1, 0, line1, 0, ReviewStatus.TENTATIVELY_READ);

--- a/java/com/google/gerrit/server/change/PatchSetInserter.java
+++ b/java/com/google/gerrit/server/change/PatchSetInserter.java
@@ -96,6 +96,7 @@ public class PatchSetInserter implements BatchUpdateOp {
   private final DiffOperationsForCommitValidation.Factory diffOperationsForCommitValidationFactory;
   private final PluginSetContext<ValidationOptionsListener> validationOptionsListeners;
   private final PluginSetContext<CommitValidationInfoListener> commitValidationInfoListeners;
+  private final LineReviewPropagation lineReviewPropagation;
 
   // Assisted-injected fields.
   private final PatchSet.Id psId;
@@ -131,6 +132,7 @@ public class PatchSetInserter implements BatchUpdateOp {
   private boolean oldWorkInProgressState;
   private ApprovalCopier.Result approvalCopierResult;
   private ObjectId preUpdateMetaId;
+  private PatchSet priorPatchSet;
 
   @Inject
   public PatchSetInserter(
@@ -150,6 +152,7 @@ public class PatchSetInserter implements BatchUpdateOp {
       DiffOperationsForCommitValidation.Factory diffOperationsForCommitValidationFactory,
       PluginSetContext<ValidationOptionsListener> validationOptionsListeners,
       PluginSetContext<CommitValidationInfoListener> commitValidationInfoListeners,
+      LineReviewPropagation lineReviewPropagation,
       @Assisted ChangeNotes notes,
       @Assisted PatchSet.Id psId,
       @Assisted ObjectId commitId) {
@@ -169,6 +172,7 @@ public class PatchSetInserter implements BatchUpdateOp {
     this.diffOperationsForCommitValidationFactory = diffOperationsForCommitValidationFactory;
     this.validationOptionsListeners = validationOptionsListeners;
     this.commitValidationInfoListeners = commitValidationInfoListeners;
+    this.lineReviewPropagation = lineReviewPropagation;
 
     this.origNotes = notes;
     this.psId = psId;
@@ -335,11 +339,11 @@ public class PatchSetInserter implements BatchUpdateOp {
               change.getId(), ChangeUtil.status(change)));
     }
 
+    priorPatchSet = psUtil.current(ctx.getNotes());
     List<String> newGroups = groups;
     if (newGroups.isEmpty()) {
-      PatchSet prevPs = psUtil.current(ctx.getNotes());
-      if (prevPs != null) {
-        newGroups = prevPs.groups();
+      if (priorPatchSet != null) {
+        newGroups = priorPatchSet.groups();
       }
     }
     patchSet =
@@ -443,6 +447,10 @@ public class PatchSetInserter implements BatchUpdateOp {
 
     if (workInProgress != null && oldWorkInProgressState != workInProgress) {
       wipStateChanged.fire(ctx.getChangeData(change), patchSet, ctx.getAccount(), ctx.getWhen());
+    }
+
+    if (priorPatchSet != null) {
+      lineReviewPropagation.propagateOnNewPatchSet(change, priorPatchSet, patchSet);
     }
   }
 

--- a/java/com/google/gerrit/server/change/PatchSetInserter.java
+++ b/java/com/google/gerrit/server/change/PatchSetInserter.java
@@ -450,6 +450,9 @@ public class PatchSetInserter implements BatchUpdateOp {
     }
 
     if (priorPatchSet != null) {
+      // Carry forward line/region review markers that still map into the new patch set.
+      // These rows are inserted as TENTATIVELY_READ to represent unmodified carryover, not an
+      // explicit review action on this patch set.
       lineReviewPropagation.propagateOnNewPatchSet(change, priorPatchSet, patchSet);
     }
   }

--- a/java/com/google/gerrit/server/git/receive/ReplaceOp.java
+++ b/java/com/google/gerrit/server/git/receive/ReplaceOp.java
@@ -588,6 +588,8 @@ public class ReplaceOp implements BatchUpdateOp {
     if (newPatchSet != null && rejectionReason == null) {
       PatchSet priorPs = notes.getPatchSets().get(priorPatchSetId);
       if (priorPs != null) {
+        // Mirror the PatchSetInserter path: when a replacement patch set is pushed, propagate
+        // mapped line/region markers as TENTATIVELY_READ carryover for unchanged regions.
         lineReviewPropagation.propagateOnNewPatchSet(notes.getChange(), priorPs, newPatchSet);
       }
     }

--- a/java/com/google/gerrit/server/git/receive/ReplaceOp.java
+++ b/java/com/google/gerrit/server/git/receive/ReplaceOp.java
@@ -54,6 +54,7 @@ import com.google.gerrit.server.approval.ApprovalsUtil;
 import com.google.gerrit.server.change.ChangeKindCache;
 import com.google.gerrit.server.change.EmailNewPatchSet;
 import com.google.gerrit.server.change.NotifyResolver;
+import com.google.gerrit.server.change.LineReviewPropagation;
 import com.google.gerrit.server.change.ReviewerModifier;
 import com.google.gerrit.server.change.ReviewerModifier.InternalReviewerInput;
 import com.google.gerrit.server.change.ReviewerModifier.ReviewerModification;
@@ -145,6 +146,7 @@ public class ReplaceOp implements BatchUpdateOp {
   private final TopicValidator topicValidator;
   private final DiffOperationsForCommitValidation.Factory diffOperationsForCommitValidationFactory;
   private final PluginSetContext<CommitValidationInfoListener> commitValidationInfoListeners;
+  private final LineReviewPropagation lineReviewPropagation;
 
   private final ProjectState projectState;
   private final Change change;
@@ -194,6 +196,7 @@ public class ReplaceOp implements BatchUpdateOp {
       TopicValidator topicValidator,
       DiffOperationsForCommitValidation.Factory diffOperationsForCommitValidationFactory,
       PluginSetContext<CommitValidationInfoListener> commitValidationInfoListeners,
+      LineReviewPropagation lineReviewPropagation,
       @Assisted ProjectState projectState,
       @Assisted Change change,
       @Assisted boolean checkMergedInto,
@@ -226,6 +229,7 @@ public class ReplaceOp implements BatchUpdateOp {
     this.topicValidator = topicValidator;
     this.diffOperationsForCommitValidationFactory = diffOperationsForCommitValidationFactory;
     this.commitValidationInfoListeners = commitValidationInfoListeners;
+    this.lineReviewPropagation = lineReviewPropagation;
 
     this.projectState = projectState;
     this.change = change;
@@ -580,6 +584,12 @@ public class ReplaceOp implements BatchUpdateOp {
     }
     if (mergedByPushOp != null) {
       mergedByPushOp.postUpdate(ctx);
+    }
+    if (newPatchSet != null && rejectionReason == null) {
+      PatchSet priorPs = notes.getPatchSets().get(priorPatchSetId);
+      if (priorPs != null) {
+        lineReviewPropagation.propagateOnNewPatchSet(notes.getChange(), priorPs, newPatchSet);
+      }
     }
   }
 

--- a/java/com/google/gerrit/server/restapi/change/ReviewedLines.java
+++ b/java/com/google/gerrit/server/restapi/change/ReviewedLines.java
@@ -60,6 +60,8 @@ public class ReviewedLines {
               LineReviewedInfo info = new LineReviewedInfo();
               info.line = line.lineNumber();
               info.side = line.getSide();
+              // Can be READ (explicit in this patch set) or TENTATIVELY_READ (propagated from a
+              // prior patch set for unchanged regions).
               info.status = line.reviewStatus();
               if (line.startLine() != line.endLine()
                   || line.startChar() != 0

--- a/java/com/google/gerrit/server/restapi/change/ReviewedLines.java
+++ b/java/com/google/gerrit/server/restapi/change/ReviewedLines.java
@@ -60,7 +60,7 @@ public class ReviewedLines {
               LineReviewedInfo info = new LineReviewedInfo();
               info.line = line.lineNumber();
               info.side = line.getSide();
-              info.status = ReviewStatus.READ;
+              info.status = line.reviewStatus();
               if (line.startLine() != line.endLine()
                   || line.startChar() != 0
                   || line.endChar() != 0) {

--- a/java/com/google/gerrit/server/restapi/change/ReviewedLines.java
+++ b/java/com/google/gerrit/server/restapi/change/ReviewedLines.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.server.restapi.change;
 
+import com.google.gerrit.extensions.client.ReviewStatus;
 import com.google.gerrit.extensions.common.LineReviewedInfo;
 import com.google.gerrit.extensions.restapi.BadRequestException;
 import com.google.gerrit.extensions.restapi.Response;
@@ -59,6 +60,7 @@ public class ReviewedLines {
               LineReviewedInfo info = new LineReviewedInfo();
               info.line = line.lineNumber();
               info.side = line.getSide();
+              info.status = ReviewStatus.READ;
               if (line.startLine() != line.endLine()
                   || line.startChar() != 0
                   || line.endChar() != 0) {
@@ -93,6 +95,9 @@ public class ReviewedLines {
         throws BadRequestException {
       if (input == null || input.line == null || input.line < 1) {
         throw new BadRequestException("line is required (1-based)");
+      }
+      if (input.status != null && input.status != ReviewStatus.READ) {
+        throw new BadRequestException("only READ may be set when marking a line reviewed");
       }
       boolean updated =
           accountPatchLineReviewStore.call(

--- a/java/com/google/gerrit/server/schema/CloudSpannerAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/CloudSpannerAccountPatchLineReviewStore.java
@@ -21,6 +21,7 @@ import com.google.gerrit.server.config.SitePaths;
 import com.google.gerrit.server.config.ThreadSettingsConfig;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.eclipse.jgit.lib.Config;
@@ -59,7 +60,9 @@ public class CloudSpannerAccountPatchLineReviewStore extends JdbcAccountPatchLin
             + "start_line INT64 NOT NULL DEFAULT (1),"
             + "start_char INT64 NOT NULL DEFAULT (0),"
             + "end_line INT64 NOT NULL DEFAULT (1),"
-            + "end_char INT64 NOT NULL DEFAULT (0)"
+            + "end_char INT64 NOT NULL DEFAULT (0),"
+            + "review_status INT64 NOT NULL DEFAULT (0),"
+            + "tentative_carryover BOOL NOT NULL DEFAULT (FALSE)"
             + ") PRIMARY KEY(change_id, patch_set_id, account_id, file_name, line_number, side, "
             + "start_line, start_char, end_line, end_char)");
   }

--- a/java/com/google/gerrit/server/schema/CloudSpannerAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/CloudSpannerAccountPatchLineReviewStore.java
@@ -21,14 +21,21 @@ import com.google.gerrit.server.config.SitePaths;
 import com.google.gerrit.server.config.ThreadSettingsConfig;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.eclipse.jgit.lib.Config;
 
+/**
+ * {@link JdbcAccountPatchLineReviewStore} for Cloud Spanner via the Spanner JDBC driver.
+ *
+ * <p>DDL uses Spanner types ({@code INT64}, {@code STRING(MAX)}, {@code BOOL}) with the same logical
+ * columns as other dialects. {@link #convertError} maps JDBC error code {@value #ERR_DUP_KEY}
+ * (Spanner duplicate key / already exists) to {@link DuplicateKeyException}.
+ */
 @Singleton
 public class CloudSpannerAccountPatchLineReviewStore extends JdbcAccountPatchLineReviewStore {
 
+  /** Spanner JDBC driver: duplicate primary key or unique index violation. */
   private static final int ERR_DUP_KEY = 6;
 
   @Inject
@@ -47,6 +54,12 @@ public class CloudSpannerAccountPatchLineReviewStore extends JdbcAccountPatchLin
     };
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Uses Spanner column types; semantics match {@link JdbcAccountPatchLineReviewStore} defaults
+   * for review status and tentative carryover across patch sets.
+   */
   @Override
   protected void doCreateTable(Statement stmt) throws SQLException {
     stmt.executeUpdate(

--- a/java/com/google/gerrit/server/schema/H2AccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/H2AccountPatchLineReviewStore.java
@@ -26,6 +26,14 @@ import java.sql.SQLException;
 import javax.sql.DataSource;
 import org.eclipse.jgit.lib.Config;
 
+/**
+ * {@link JdbcAccountPatchLineReviewStore} for H2 (default on-disk site DB or explicit {@code
+ * jdbc:h2:...} URL).
+ *
+ * <p>{@link #convertError} maps SQLSTATE {@code 23001}/{@code 23505} to {@link DuplicateKeyException}
+ * so {@link com.google.gerrit.server.change.LineReviewPropagation} can treat a duplicate row as a
+ * benign skip when inserting carried-over tentative markers.
+ */
 @Singleton
 public class H2AccountPatchLineReviewStore extends JdbcAccountPatchLineReviewStore {
 

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -864,7 +864,8 @@ public abstract class JdbcAccountPatchLineReviewStore
                     rs.getInt(COL_START_LINE),
                     rs.getInt(COL_START_CHAR),
                     rs.getInt(COL_END_LINE),
-                    rs.getInt(COL_END_CHAR)));
+                    rs.getInt(COL_END_CHAR),
+                    ReviewStatus.fromDbValue(rs.getShort("review_status"))));
           }
           ImmutableList<ReviewedLine> lines = builder.build();
           if (lines.isEmpty()) {
@@ -987,7 +988,7 @@ public abstract class JdbcAccountPatchLineReviewStore
         PreparedStatement stmt =
             con.prepareStatement(
                 "SELECT account_id, file_name, line_number, side, start_line, start_char, "
-                    + "end_line, end_char "
+                    + "end_line, end_char, review_status "
                     + "FROM account_patch_line_reviews "
                     + "WHERE change_id = ? AND patch_set_id = ? AND file_name = ? "
                     + "ORDER BY account_id, line_number")) {
@@ -1008,7 +1009,8 @@ public abstract class JdbcAccountPatchLineReviewStore
                       rs.getInt(COL_START_LINE),
                       rs.getInt(COL_START_CHAR),
                       rs.getInt(COL_END_LINE),
-                      rs.getInt(COL_END_CHAR)));
+                      rs.getInt(COL_END_CHAR),
+                      ReviewStatus.fromDbValue(rs.getShort("review_status"))));
         }
         ImmutableMap.Builder<Account.Id, ImmutableList<ReviewedLine>> result =
             ImmutableMap.builder();

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -18,6 +18,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
 import com.google.common.primitives.Ints;
 import com.google.gerrit.entities.Account;
@@ -598,6 +599,99 @@ public abstract class JdbcAccountPatchLineReviewStore
       stmt.executeUpdate();
     } catch (SQLException e) {
       throw convertError("delete", e);
+    }
+  }
+
+  @Override
+  public ImmutableSet<Account.Id> accountsWithLineReviews(PatchSet.Id psId) {
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "List accounts with line reviews on patch set",
+                Metadata.builder().patchSetId(psId.get()).build());
+        Connection con = ds.getConnection();
+        PreparedStatement stmt =
+            con.prepareStatement(
+                "SELECT DISTINCT account_id FROM account_patch_line_reviews WHERE change_id = ? "
+                    + "AND patch_set_id = ?")) {
+      stmt.setInt(1, psId.changeId().get());
+      stmt.setInt(2, psId.get());
+      try (ResultSet rs = stmt.executeQuery()) {
+        ImmutableSet.Builder<Account.Id> b = ImmutableSet.builder();
+        while (rs.next()) {
+          b.add(Account.id(rs.getInt(1)));
+        }
+        return b.build();
+      }
+    } catch (SQLException e) {
+      throw convertError("select", e);
+    }
+  }
+
+  @Override
+  public void insertPropagatedTentativeReviews(
+      PatchSet.Id psId, Account.Id accountId, Collection<ReviewedLine> lines) {
+    if (lines == null || lines.isEmpty()) {
+      return;
+    }
+    String exists =
+        "SELECT 1 FROM account_patch_line_reviews WHERE account_id = ? AND change_id = ? "
+            + "AND patch_set_id = ? AND file_name = ? AND line_number = ? AND side = ? "
+            + "AND start_line = ? AND start_char = ? AND end_line = ? AND end_char = ?";
+    String insert =
+        "INSERT INTO account_patch_line_reviews "
+            + "(account_id, change_id, patch_set_id, file_name, line_number, side, "
+            + "start_line, start_char, end_line, end_char, review_status, tentative_carryover) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "Insert propagated tentative line reviews",
+                Metadata.builder()
+                    .patchSetId(psId.get())
+                    .accountId(accountId.get())
+                    .build());
+        Connection con = ds.getConnection()) {
+      try (PreparedStatement existsStmt = con.prepareStatement(exists);
+          PreparedStatement insertStmt = con.prepareStatement(insert)) {
+        for (ReviewedLine line : lines) {
+          if (line == null) {
+            continue;
+          }
+          bindLineGeometry(
+              existsStmt,
+              1,
+              accountId,
+              psId,
+              line.path(),
+              line.lineNumber(),
+              line.side(),
+              line.startLine(),
+              line.startChar(),
+              line.endLine(),
+              line.endChar());
+          try (ResultSet rs = existsStmt.executeQuery()) {
+            if (rs.next()) {
+              continue;
+            }
+          }
+          bindLineGeometry(
+              insertStmt,
+              1,
+              accountId,
+              psId,
+              line.path(),
+              line.lineNumber(),
+              line.side(),
+              line.startLine(),
+              line.startChar(),
+              line.endLine(),
+              line.endChar());
+          insertStmt.setShort(11, ReviewStatus.TENTATIVELY_READ.toDbValue());
+          insertStmt.setBoolean(12, true);
+          insertStmt.executeUpdate();
+        }
+      }
+    } catch (SQLException e) {
+      throw convertError("insertPropagatedTentativeReviews", e);
     }
   }
 

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -57,6 +57,25 @@ import javax.sql.DataSource;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.eclipse.jgit.lib.Config;
 
+/**
+ * JDBC persistence for per-account line/region review markers on a patch set.
+ *
+ * <p>Table {@code account_patch_line_reviews} backs the {@code reviewed_lines} REST API and
+ * derived summaries such as {@code line_review_progress}. Each row is one reviewed region
+ * identified by change, patch set, account, file path, side, and full line/char geometry (the
+ * composite primary key).
+ *
+ * <p>Columns {@code review_status} and {@code tentative_carryover} distinguish explicit {@code
+ * READ} marks from rows created when {@link com.google.gerrit.server.change.LineReviewPropagation}
+ * carries markers forward as {@code TENTATIVELY_READ}. Clearing a carried-over {@code READ} can
+ * downgrade back to tentative instead of deleting the row.
+ *
+ * <p>Configuration: JDBC URL is read from {@code accountPatchLineReviewDb.url}, or the legacy
+ * {@code accountPatchReviewDb.url}. If unset, the site defaults to an on-disk H2 database under
+ * {@code SitePaths}. Subclasses ({@link H2AccountPatchLineReviewStore}, {@link
+ * PostgresqlAccountPatchLineReviewStore}, etc.) differ mainly in {@link #convertError} and
+ * sometimes {@link #doCreateTable} (e.g. shorter {@code file_name} for MySQL/MariaDB key limits).
+ */
 public abstract class JdbcAccountPatchLineReviewStore
     implements AccountPatchLineReviewStore, LifecycleListener {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
@@ -73,6 +92,11 @@ public abstract class JdbcAccountPatchLineReviewStore
   private static final String CLOUDSPANNER = "cloudspanner";
   private static final String URL = "url";
 
+  /**
+   * Guice module that binds {@link AccountPatchLineReviewStore} to the JDBC implementation chosen
+   * from {@code accountPatchLineReviewDb.url} or legacy {@code accountPatchReviewDb.url} (driver
+   * family inferred from URL substrings such as {@code postgresql}, {@code mysql}).
+   */
   public static class JdbcAccountPatchLineReviewStoreModule extends LifecycleModule {
     private final Config cfg;
 
@@ -195,7 +219,10 @@ public abstract class JdbcAccountPatchLineReviewStore
     return side == Side.PARENT ? (short) 0 : (short) 1;
   }
 
-  /** Normalize input to (lineNumber, startLine, startChar, endLine, endChar). */
+  /**
+   * Fills {@code lineNumber} and range arrays from REST input: uses {@code line} when present, or
+   * derives a single-line range from {@code range} when valid; otherwise defaults to line 1.
+   */
   protected static void normalizeInput(
       LineReviewedInput input,
       int[] lineNumber,
@@ -233,10 +260,12 @@ public abstract class JdbcAccountPatchLineReviewStore
     }
   }
 
+  /** Returns a connection from the store's pool (used by tests and maintenance). */
   public Connection getConnection() throws SQLException {
     return ds.getConnection();
   }
 
+  /** Creates {@code account_patch_line_reviews} if missing, then runs {@link #upgradeSchema}. */
   public void createTableIfNotExists() {
     try (Connection con = ds.getConnection()) {
       try (Statement stmt = con.createStatement()) {
@@ -249,10 +278,15 @@ public abstract class JdbcAccountPatchLineReviewStore
   }
 
   /**
-   * Adds {@code review_status} and {@code tentative_carryover} for databases without these new columns.
+   * Adds {@code review_status} and {@code tentative_carryover} when upgrading sites that created
+   * {@code account_patch_line_reviews} before those columns existed.
+   *
+   * <p>{@code review_status} stores {@link ReviewStatus} DB values; {@code tentative_carryover}
+   * marks rows inserted by propagation so "clear reviewed" can revert READ to tentative instead of
+   * losing the carried hint entirely.
    */
   protected void upgradeSchema(Connection con) throws SQLException {
-    // see what columns there are and add the two columns if not present already
+    // Introspect current table shape; ALTER only missing columns so this is safe across dialects.
     try (Statement checkStmt = con.createStatement();
         ResultSet rs = checkStmt.executeQuery("SELECT * FROM account_patch_line_reviews WHERE 1=0")) {
       ResultSetMetaData md = rs.getMetaData();
@@ -275,6 +309,10 @@ public abstract class JdbcAccountPatchLineReviewStore
     }
   }
 
+  /**
+   * Default DDL for H2/PostgreSQL-style limits. MySQL/MariaDB override with a shorter {@code
+   * file_name} so the composite primary key fits engine index limits.
+   */
   protected void doCreateTable(Statement stmt) throws SQLException {
     stmt.executeUpdate(
         "CREATE TABLE IF NOT EXISTS account_patch_line_reviews ("
@@ -318,7 +356,8 @@ public abstract class JdbcAccountPatchLineReviewStore
                     .build());
         Connection con = ds.getConnection()) {
       boolean prevAutoCommit = con.getAutoCommit();
-      con.setAutoCommit(false); // transaction to ensure atomicity
+      // Select-then-insert/update must be atomic so concurrent reviewers do not double-insert.
+      con.setAutoCommit(false);
       try {
         boolean updated =
             markLineReviewedInTransaction(
@@ -372,7 +411,7 @@ public abstract class JdbcAccountPatchLineReviewStore
           sel, 1, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
       try (ResultSet rs = sel.executeQuery()) {
         if (!rs.next()) {
-          // no row found, insert a new one
+          // No row for this geometry: insert explicit READ (not carryover).
           try (PreparedStatement ins =
               con.prepareStatement(
                   "INSERT INTO account_patch_line_reviews "
@@ -410,7 +449,7 @@ public abstract class JdbcAccountPatchLineReviewStore
     }
   }
 
-  // fill in the placeholders in the query
+  /** Binds the composite line identity (account, change, patch set, path, geometry) from {@code startIdx}. */
   private static void bindLineGeometry(
       PreparedStatement stmt,
       int startIdx,
@@ -470,6 +509,7 @@ public abstract class JdbcAccountPatchLineReviewStore
                     .build());
         Connection con = ds.getConnection()) {
       boolean prevAutoCommit = con.getAutoCommit();
+      // Select-then-update/delete must be atomic for correct carryover downgrade vs delete.
       con.setAutoCommit(false);
       try {
         clearLineReviewedInTransaction(
@@ -627,6 +667,11 @@ public abstract class JdbcAccountPatchLineReviewStore
     }
   }
 
+  /**
+   * Inserts propagated tentative rows one-by-one, skipping geometries that already exist (so
+   * re-running propagation or overlapping sources does not violate the primary key). Callers
+   * should pass mapped {@link ReviewedLine} rows; this method sets status and carryover flags.
+   */
   @Override
   public void insertPropagatedTentativeReviews(
       PatchSet.Id psId, Account.Id accountId, Collection<ReviewedLine> lines) {
@@ -748,6 +793,12 @@ public abstract class JdbcAccountPatchLineReviewStore
     }
   }
 
+  /**
+   * Maps JDBC failures to Gerrit storage exceptions. This default always wraps as {@link
+   * StorageException}; dialect subclasses map unique-violation codes (for example PostgreSQL
+   * {@code SQLSTATE 23505}) to {@link DuplicateKeyException} so concurrent propagation inserts can
+   * be treated as idempotent skips.
+   */
   public StorageException convertError(String op, SQLException err) {
     if (err.getCause() == null && err.getNextException() != null) {
       err.initCause(err.getNextException());
@@ -755,6 +806,7 @@ public abstract class JdbcAccountPatchLineReviewStore
     return new StorageException(op + " failure on account_patch_line_reviews", err);
   }
 
+  /** Parses {@link SQLException#getSQLState()} from this exception or its chain for dialect switches. */
   protected static int getSQLStateInt(SQLException err) {
     String s = getSQLState(err);
     if (s != null) {

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -26,6 +26,7 @@ import com.google.gerrit.entities.PatchSet;
 import com.google.gerrit.exceptions.DuplicateKeyException;
 import com.google.gerrit.exceptions.StorageException;
 import com.google.gerrit.extensions.api.changes.LineReviewedInput;
+import com.google.gerrit.extensions.client.ReviewStatus;
 import com.google.gerrit.extensions.client.Side;
 import com.google.gerrit.extensions.events.LifecycleListener;
 import com.google.gerrit.extensions.registration.DynamicItem;
@@ -42,11 +43,15 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collection;
-import com.google.common.annotations.VisibleForTesting;
+import java.util.HashSet;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
+import com.google.common.annotations.VisibleForTesting;
 import javax.sql.DataSource;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.eclipse.jgit.lib.Config;
@@ -232,11 +237,40 @@ public abstract class JdbcAccountPatchLineReviewStore
   }
 
   public void createTableIfNotExists() {
-    try (Connection con = ds.getConnection();
-        Statement stmt = con.createStatement()) {
-      doCreateTable(stmt);
+    try (Connection con = ds.getConnection()) {
+      try (Statement stmt = con.createStatement()) {
+        doCreateTable(stmt);
+      }
+      upgradeSchema(con);
     } catch (SQLException e) {
       throw convertError("create", e);
+    }
+  }
+
+  /**
+   * Adds {@code review_status} and {@code tentative_carryover} for databases without these new columns.
+   */
+  protected void upgradeSchema(Connection con) throws SQLException {
+    // see what columns there are and add the two columns if not present already
+    try (Statement checkStmt = con.createStatement();
+        ResultSet rs = checkStmt.executeQuery("SELECT * FROM account_patch_line_reviews WHERE 1=0")) {
+      ResultSetMetaData md = rs.getMetaData();
+      Set<String> cols = new HashSet<>();
+      for (int i = 1; i <= md.getColumnCount(); i++) {
+        cols.add(md.getColumnLabel(i).toLowerCase(Locale.US));
+      }
+      try (Statement alter = con.createStatement()) {
+        if (!cols.contains("review_status")) {
+          alter.executeUpdate(
+              "ALTER TABLE account_patch_line_reviews ADD COLUMN review_status "
+                  + "SMALLINT NOT NULL DEFAULT 0");
+        }
+        if (!cols.contains("tentative_carryover")) {
+          alter.executeUpdate(
+              "ALTER TABLE account_patch_line_reviews ADD COLUMN tentative_carryover "
+                  + "BOOLEAN NOT NULL DEFAULT FALSE");
+        }
+      }
     }
   }
 
@@ -253,6 +287,8 @@ public abstract class JdbcAccountPatchLineReviewStore
             + "start_char INTEGER DEFAULT 0 NOT NULL, "
             + "end_line INTEGER DEFAULT 1 NOT NULL, "
             + "end_char INTEGER DEFAULT 0 NOT NULL, "
+            + "review_status SMALLINT DEFAULT 0 NOT NULL, "
+            + "tentative_carryover BOOLEAN DEFAULT FALSE NOT NULL, "
             + "CONSTRAINT primary_key_account_patch_line_reviews "
             + "PRIMARY KEY (change_id, patch_set_id, account_id, file_name, line_number, side, "
             + "start_line, start_char, end_line, end_char)"
@@ -269,6 +305,7 @@ public abstract class JdbcAccountPatchLineReviewStore
     int[] lineNumber = new int[1];
     int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
     normalizeInput(input, lineNumber, startLine, startChar, endLine, endChar);
+    short sideShort = sideToShort(side);
 
     try (TraceTimer ignored =
             TraceContext.newTimer(
@@ -278,32 +315,125 @@ public abstract class JdbcAccountPatchLineReviewStore
                     .accountId(accountId.get())
                     .filePath(path)
                     .build());
-        Connection con = ds.getConnection();
-        PreparedStatement stmt =
-            con.prepareStatement(
-                "INSERT INTO account_patch_line_reviews "
-                    + "(account_id, change_id, patch_set_id, file_name, line_number, side, "
-                    + "start_line, start_char, end_line, end_char) VALUES "
-                    + "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
-      stmt.setInt(1, accountId.get());
-      stmt.setInt(2, psId.changeId().get());
-      stmt.setInt(3, psId.get());
-      stmt.setString(4, path);
-      stmt.setInt(5, lineNumber[0]);
-      stmt.setShort(6, sideToShort(side));
-      stmt.setInt(7, startLine[0]);
-      stmt.setInt(8, startChar[0]);
-      stmt.setInt(9, endLine[0]);
-      stmt.setInt(10, endChar[0]);
-      stmt.executeUpdate();
-      return true;
+        Connection con = ds.getConnection()) {
+      boolean prevAutoCommit = con.getAutoCommit();
+      con.setAutoCommit(false); // transaction to ensure atomicity
+      try {
+        boolean updated =
+            markLineReviewedInTransaction(
+                con,
+                psId,
+                accountId,
+                path,
+                lineNumber[0],
+                sideShort,
+                startLine[0],
+                startChar[0],
+                endLine[0],
+                endChar[0]);
+        con.commit();
+        return updated;
+      } catch (SQLException e) {
+        con.rollback();
+        throw convertError("markLineReviewed", e);
+      } finally {
+        con.setAutoCommit(prevAutoCommit);
+      }
     } catch (SQLException e) {
-      StorageException ormException = convertError("insert", e);
-      if (ormException instanceof DuplicateKeyException) {
+      throw convertError("markLineReviewed", e);
+    }
+  }
+
+  /**
+   * Marks a line {@link ReviewStatus#READ} via the REST API: inserts a new row, upgrades {@link
+   * ReviewStatus#TENTATIVELY_READ} to READ while preserving {@code tentative_carryover}, or does
+   * nothing if already READ.
+   */
+  private boolean markLineReviewedInTransaction(
+      Connection con,
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      int lineNumber,
+      short side,
+      int startLine,
+      int startChar,
+      int endLine,
+      int endChar)
+      throws SQLException {
+    String select =
+        "SELECT review_status, tentative_carryover FROM account_patch_line_reviews WHERE "
+            + "account_id = ? AND change_id = ? AND patch_set_id = ? AND file_name = ? "
+            + "AND line_number = ? AND side = ? AND start_line = ? AND start_char = ? "
+            + "AND end_line = ? AND end_char = ?";
+    try (PreparedStatement sel = con.prepareStatement(select)) {
+      bindLineGeometry(
+          sel, 1, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
+      try (ResultSet rs = sel.executeQuery()) {
+        if (!rs.next()) {
+          // no row found, insert a new one
+          try (PreparedStatement ins =
+              con.prepareStatement(
+                  "INSERT INTO account_patch_line_reviews "
+                      + "(account_id, change_id, patch_set_id, file_name, line_number, side, "
+                      + "start_line, start_char, end_line, end_char, review_status, "
+                      + "tentative_carryover) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+            bindLineGeometry(
+                ins, 1, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
+            ins.setShort(11, ReviewStatus.READ.toDbValue());
+            ins.setBoolean(12, false);
+            ins.executeUpdate();
+            return true;
+          }
+        }
+        ReviewStatus current = ReviewStatus.fromDbValue(rs.getShort(1));
+        if (current == ReviewStatus.READ) {
+          return false;
+        }
+        if (current == ReviewStatus.TENTATIVELY_READ) {
+          try (PreparedStatement upd =
+              con.prepareStatement(
+                  "UPDATE account_patch_line_reviews SET review_status = ? WHERE "
+                      + "account_id = ? AND change_id = ? AND patch_set_id = ? AND file_name = ? "
+                      + "AND line_number = ? AND side = ? AND start_line = ? AND start_char = ? "
+                      + "AND end_line = ? AND end_char = ?")) {
+            upd.setShort(1, ReviewStatus.READ.toDbValue());
+            bindLineGeometry(
+                upd, 2, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
+            upd.executeUpdate();
+            return true;
+          }
+        }
         return false;
       }
-      throw ormException;
     }
+  }
+
+  // fill in the placeholders in the query
+  private static void bindLineGeometry(
+      PreparedStatement stmt,
+      int startIdx,
+      Account.Id accountId,
+      PatchSet.Id psId,
+      String path,
+      int lineNumber,
+      short side,
+      int startLine,
+      int startChar,
+      int endLine,
+      int endChar)
+      throws SQLException {
+    int i = startIdx;
+    stmt.setInt(i++, accountId.get());
+    stmt.setInt(i++, psId.changeId().get());
+    stmt.setInt(i++, psId.get());
+    stmt.setString(i++, path);
+    stmt.setInt(i++, lineNumber);
+    stmt.setShort(i++, side);
+    stmt.setInt(i++, startLine);
+    stmt.setInt(i++, startChar);
+    stmt.setInt(i++, endLine);
+    stmt.setInt(i++, endChar);
   }
 
   @Override
@@ -327,6 +457,7 @@ public abstract class JdbcAccountPatchLineReviewStore
     int[] lineNumber = new int[1];
     int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
     normalizeInput(input, lineNumber, startLine, startChar, endLine, endChar);
+    short sideShort = sideToShort(side);
 
     try (TraceTimer ignored =
             TraceContext.newTimer(
@@ -336,25 +467,87 @@ public abstract class JdbcAccountPatchLineReviewStore
                     .accountId(accountId.get())
                     .filePath(path)
                     .build());
-        Connection con = ds.getConnection();
-        PreparedStatement stmt =
-            con.prepareStatement(
-                "DELETE FROM account_patch_line_reviews WHERE account_id = ? AND change_id = ? "
-                    + "AND patch_set_id = ? AND file_name = ? AND line_number = ? AND side = ? "
-                    + "AND start_line = ? AND start_char = ? AND end_line = ? AND end_char = ?")) {
-      stmt.setInt(1, accountId.get());
-      stmt.setInt(2, psId.changeId().get());
-      stmt.setInt(3, psId.get());
-      stmt.setString(4, path);
-      stmt.setInt(5, lineNumber[0]);
-      stmt.setShort(6, sideToShort(side));
-      stmt.setInt(7, startLine[0]);
-      stmt.setInt(8, startChar[0]);
-      stmt.setInt(9, endLine[0]);
-      stmt.setInt(10, endChar[0]);
-      stmt.executeUpdate();
+        Connection con = ds.getConnection()) {
+      boolean prevAutoCommit = con.getAutoCommit();
+      con.setAutoCommit(false);
+      try {
+        clearLineReviewedInTransaction(
+            con,
+            psId,
+            accountId,
+            path,
+            lineNumber[0],
+            sideShort,
+            startLine[0],
+            startChar[0],
+            endLine[0],
+            endChar[0]);
+        con.commit();
+      } catch (SQLException e) {
+        con.rollback();
+        throw convertError("clearLineReviewed", e);
+      } finally {
+        con.setAutoCommit(prevAutoCommit);
+      }
     } catch (SQLException e) {
-      throw convertError("delete", e);
+      throw convertError("clearLineReviewed", e);
+    }
+  }
+
+  /**
+   * If the row is {@link ReviewStatus#READ} with {@code tentative_carryover}, downgrade to {@link
+   * ReviewStatus#TENTATIVELY_READ}; otherwise delete the row (unread or dismissing tentative).
+   */
+  private void clearLineReviewedInTransaction(
+      Connection con,
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      int lineNumber,
+      short side,
+      int startLine,
+      int startChar,
+      int endLine,
+      int endChar)
+      throws SQLException {
+    String select =
+        "SELECT review_status, tentative_carryover FROM account_patch_line_reviews WHERE "
+            + "account_id = ? AND change_id = ? AND patch_set_id = ? AND file_name = ? "
+            + "AND line_number = ? AND side = ? AND start_line = ? AND start_char = ? "
+            + "AND end_line = ? AND end_char = ?";
+    try (PreparedStatement sel = con.prepareStatement(select)) {
+      bindLineGeometry(
+          sel, 1, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
+      try (ResultSet rs = sel.executeQuery()) {
+        if (!rs.next()) {
+          return;
+        }
+        ReviewStatus current = ReviewStatus.fromDbValue(rs.getShort(1));
+        boolean carry = rs.getBoolean(2);
+        if (current == ReviewStatus.READ && carry) {
+          try (PreparedStatement upd =
+              con.prepareStatement(
+                  "UPDATE account_patch_line_reviews SET review_status = ? WHERE "
+                      + "account_id = ? AND change_id = ? AND patch_set_id = ? AND file_name = ? "
+                      + "AND line_number = ? AND side = ? AND start_line = ? AND start_char = ? "
+                      + "AND end_line = ? AND end_char = ?")) {
+            upd.setShort(1, ReviewStatus.TENTATIVELY_READ.toDbValue());
+            bindLineGeometry(
+                upd, 2, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
+            upd.executeUpdate();
+          }
+        } else {
+          try (PreparedStatement del =
+              con.prepareStatement(
+                  "DELETE FROM account_patch_line_reviews WHERE account_id = ? AND change_id = ? "
+                      + "AND patch_set_id = ? AND file_name = ? AND line_number = ? AND side = ? "
+                      + "AND start_line = ? AND start_char = ? AND end_line = ? AND end_char = ?")) {
+            bindLineGeometry(
+                del, 1, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
+            del.executeUpdate();
+          }
+        }
+      }
     }
   }
 
@@ -420,7 +613,8 @@ public abstract class JdbcAccountPatchLineReviewStore
                     .build());
         Connection con = ds.getConnection()) {
       String sql =
-          "SELECT file_name, line_number, side, start_line, start_char, end_line, end_char "
+          "SELECT file_name, line_number, side, start_line, start_char, end_line, end_char, "
+              + "review_status "
               + "FROM account_patch_line_reviews "
               + "WHERE account_id = ? AND change_id = ? AND patch_set_id = ?";
       if (path != null) {
@@ -445,7 +639,8 @@ public abstract class JdbcAccountPatchLineReviewStore
                     rs.getInt("start_line"),
                     rs.getInt("start_char"),
                     rs.getInt("end_line"),
-                    rs.getInt("end_char")));
+                    rs.getInt("end_char"),
+                    ReviewStatus.fromDbValue(rs.getShort("review_status"))));
           }
           ImmutableList<ReviewedLine> lines = builder.build();
           if (lines.isEmpty()) {

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -17,6 +17,7 @@ package com.google.gerrit.server.schema;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableMap;
@@ -25,7 +26,6 @@ import com.google.common.primitives.Ints;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
-import com.google.gerrit.exceptions.DuplicateKeyException;
 import com.google.gerrit.exceptions.StorageException;
 import com.google.gerrit.extensions.api.changes.LineReviewedInput;
 import com.google.gerrit.extensions.client.ReviewStatus;
@@ -54,10 +54,8 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.Set;
-import com.google.common.annotations.VisibleForTesting;
 import javax.sql.DataSource;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.eclipse.jgit.lib.Config;
@@ -405,43 +403,6 @@ public abstract class JdbcAccountPatchLineReviewStore
                     .filePath(path)
                     .build());
         Connection con = ds.getConnection()) {
-        try (PreparedStatement stmt =
-            con.prepareStatement(
-                "INSERT INTO account_patch_line_reviews "
-                    + "(account_id, change_id, patch_set_id, file_name, line_number, side, "
-                    + "start_line, start_char, end_line, end_char) VALUES "
-                    + "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
-          stmt.setInt(1, accountId.get());
-          stmt.setInt(2, psId.changeId().get());
-          stmt.setInt(3, psId.get());
-          stmt.setString(4, path);
-          stmt.setInt(5, lineNumber[0]);
-          stmt.setShort(6, sideToShort(side));
-          stmt.setInt(7, startLine[0]);
-          stmt.setInt(8, startChar[0]);
-          stmt.setInt(9, endLine[0]);
-          stmt.setInt(10, endChar[0]);
-          stmt.executeUpdate();
-        } catch (SQLException e) {
-          StorageException ormException = convertError("insert", e);
-          if (ormException instanceof DuplicateKeyException) {
-            return false; // already marked — do not log
-          }
-          throw ormException;
-        }
-        // Log the mark action (best-effort: don't fail the main operation on history write failure)
-        try {
-          insertHistoryEntry(
-              con, psId, accountId, path, lineNumber[0],
-              sideToShort(side), startLine[0], startChar[0], endLine[0], endChar[0],
-              LineReviewAction.MARKED);
-        } catch (SQLException e) {
-          logger.atWarning().withCause(e).log("Failed to log MARKED action to history");
-        }
-        return true;
-      } catch (SQLException e) {
-        throw convertError("insert", e);
-      }
       boolean prevAutoCommit = con.getAutoCommit();
       // Select-then-insert/update must be atomic so concurrent reviewers do not double-insert.
       con.setAutoCommit(false);
@@ -459,6 +420,24 @@ public abstract class JdbcAccountPatchLineReviewStore
                 endLine[0],
                 endChar[0]);
         con.commit();
+        if (updated) {
+          try {
+            insertHistoryEntry(
+                con,
+                psId,
+                accountId,
+                path,
+                lineNumber[0],
+                sideShort,
+                startLine[0],
+                startChar[0],
+                endLine[0],
+                endChar[0],
+                LineReviewAction.MARKED);
+          } catch (SQLException e) {
+            logger.atWarning().withCause(e).log("Failed to log MARKED action to history");
+          }
+        }
         return updated;
       } catch (SQLException e) {
         con.rollback();
@@ -600,52 +579,42 @@ public abstract class JdbcAccountPatchLineReviewStore
       // Select-then-update/delete must be atomic for correct carryover downgrade vs delete.
       con.setAutoCommit(false);
       try {
-        clearLineReviewedInTransaction(
-            con,
-            psId,
-            accountId,
-            path,
-            lineNumber[0],
-            sideShort,
-            startLine[0],
-            startChar[0],
-            endLine[0],
-            endChar[0]);
+        boolean changed =
+            clearLineReviewedInTransaction(
+                con,
+                psId,
+                accountId,
+                path,
+                lineNumber[0],
+                sideShort,
+                startLine[0],
+                startChar[0],
+                endLine[0],
+                endChar[0]);
         con.commit();
+        if (changed) {
+          try {
+            insertHistoryEntry(
+                con,
+                psId,
+                accountId,
+                path,
+                lineNumber[0],
+                sideShort,
+                startLine[0],
+                startChar[0],
+                endLine[0],
+                endChar[0],
+                LineReviewAction.UNMARKED);
+          } catch (SQLException e) {
+            logger.atWarning().withCause(e).log("Failed to log UNMARKED action to history");
+          }
+        }
       } catch (SQLException e) {
         con.rollback();
         throw convertError("clearLineReviewed", e);
       } finally {
         con.setAutoCommit(prevAutoCommit);
-      }
-      int affected;
-      try (PreparedStatement stmt =
-          con.prepareStatement(
-              "DELETE FROM account_patch_line_reviews WHERE account_id = ? AND change_id = ? "
-                  + "AND patch_set_id = ? AND file_name = ? AND line_number = ? AND side = ? "
-                  + "AND start_line = ? AND start_char = ? AND end_line = ? AND end_char = ?")) {
-        stmt.setInt(1, accountId.get());
-        stmt.setInt(2, psId.changeId().get());
-        stmt.setInt(3, psId.get());
-        stmt.setString(4, path);
-        stmt.setInt(5, lineNumber[0]);
-        stmt.setShort(6, sideToShort(side));
-        stmt.setInt(7, startLine[0]);
-        stmt.setInt(8, startChar[0]);
-        stmt.setInt(9, endLine[0]);
-        stmt.setInt(10, endChar[0]);
-        affected = stmt.executeUpdate();
-      }
-      // Only log if a row was actually deleted (don't log no-ops)
-      if (affected > 0) {
-        try {
-          insertHistoryEntry(
-              con, psId, accountId, path, lineNumber[0],
-              sideToShort(side), startLine[0], startChar[0], endLine[0], endChar[0],
-              LineReviewAction.UNMARKED);
-        } catch (SQLException e) {
-          logger.atWarning().withCause(e).log("Failed to log UNMARKED action to history");
-        }
       }
     } catch (SQLException e) {
       throw convertError("clearLineReviewed", e);
@@ -656,7 +625,7 @@ public abstract class JdbcAccountPatchLineReviewStore
    * If the row is {@link ReviewStatus#READ} with {@code tentative_carryover}, downgrade to {@link
    * ReviewStatus#TENTATIVELY_READ}; otherwise delete the row (unread or dismissing tentative).
    */
-  private void clearLineReviewedInTransaction(
+  private boolean clearLineReviewedInTransaction(
       Connection con,
       PatchSet.Id psId,
       Account.Id accountId,
@@ -678,7 +647,7 @@ public abstract class JdbcAccountPatchLineReviewStore
           sel, 1, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
       try (ResultSet rs = sel.executeQuery()) {
         if (!rs.next()) {
-          return;
+          return false;
         }
         ReviewStatus current = ReviewStatus.fromDbValue(rs.getShort(1));
         boolean carry = rs.getBoolean(2);
@@ -694,16 +663,16 @@ public abstract class JdbcAccountPatchLineReviewStore
                 upd, 2, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
             upd.executeUpdate();
           }
-        } else {
-          try (PreparedStatement del =
-              con.prepareStatement(
-                  "DELETE FROM account_patch_line_reviews WHERE account_id = ? AND change_id = ? "
-                      + "AND patch_set_id = ? AND file_name = ? AND line_number = ? AND side = ? "
-                      + "AND start_line = ? AND start_char = ? AND end_line = ? AND end_char = ?")) {
-            bindLineGeometry(
-                del, 1, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
-            del.executeUpdate();
-          }
+          return true;
+        }
+        try (PreparedStatement del =
+            con.prepareStatement(
+                "DELETE FROM account_patch_line_reviews WHERE account_id = ? AND change_id = ? "
+                    + "AND patch_set_id = ? AND file_name = ? AND line_number = ? AND side = ? "
+                    + "AND start_line = ? AND start_char = ? AND end_line = ? AND end_char = ?")) {
+          bindLineGeometry(
+              del, 1, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
+          return del.executeUpdate() > 0;
         }
       }
     }
@@ -1054,7 +1023,8 @@ public abstract class JdbcAccountPatchLineReviewStore
   /**
    * Maps JDBC failures to Gerrit storage exceptions. This default always wraps as {@link
    * StorageException}; dialect subclasses map unique-violation codes (for example PostgreSQL
-   * {@code SQLSTATE 23505}) to {@link DuplicateKeyException} so concurrent propagation inserts can
+   * {@code SQLSTATE 23505}) to {@link com.google.gerrit.exceptions.DuplicateKeyException} so concurrent
+   * propagation inserts can
    * be treated as idempotent skips.
    */
   public StorageException convertError(String op, SQLException err) {

--- a/java/com/google/gerrit/server/schema/MariaDBAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/MariaDBAccountPatchLineReviewStore.java
@@ -25,6 +25,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.eclipse.jgit.lib.Config;
 
+/**
+ * {@link JdbcAccountPatchLineReviewStore} for MariaDB.
+ *
+ * <p>Same schema shape and duplicate-key handling as {@link MysqlAccountPatchLineReviewStore}
+ * (short {@code file_name}, MySQL-compatible error codes).
+ */
 @Singleton
 public class MariaDBAccountPatchLineReviewStore extends JdbcAccountPatchLineReviewStore {
 
@@ -51,6 +57,12 @@ public class MariaDBAccountPatchLineReviewStore extends JdbcAccountPatchLineRevi
     }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Uses the same shortened {@code file_name} as {@link MysqlAccountPatchLineReviewStore} so the
+   * composite primary key stays within engine index size limits.
+   */
   @Override
   protected void doCreateTable(Statement stmt) throws SQLException {
     stmt.executeUpdate(

--- a/java/com/google/gerrit/server/schema/MariaDBAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/MariaDBAccountPatchLineReviewStore.java
@@ -65,6 +65,8 @@ public class MariaDBAccountPatchLineReviewStore extends JdbcAccountPatchLineRevi
             + "start_char INTEGER DEFAULT 0 NOT NULL, "
             + "end_line INTEGER DEFAULT 1 NOT NULL, "
             + "end_char INTEGER DEFAULT 0 NOT NULL, "
+            + "review_status SMALLINT DEFAULT 0 NOT NULL, "
+            + "tentative_carryover BOOLEAN DEFAULT FALSE NOT NULL, "
             + "CONSTRAINT primary_key_account_patch_line_reviews "
             + "PRIMARY KEY (change_id, patch_set_id, account_id, file_name, line_number, side, "
             + "start_line, start_char, end_line, end_char)"

--- a/java/com/google/gerrit/server/schema/MysqlAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/MysqlAccountPatchLineReviewStore.java
@@ -25,6 +25,13 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.eclipse.jgit.lib.Config;
 
+/**
+ * {@link JdbcAccountPatchLineReviewStore} for MySQL.
+ *
+ * <p>Uses a shorter {@code file_name VARCHAR(255)} in {@link #doCreateTable} than the base class so
+ * the composite primary key stays within MySQL index size limits. Duplicate inserts are detected
+ * via vendor {@link SQLException#getErrorCode()} (e.g. 1062) in {@link #convertError}.
+ */
 @Singleton
 public class MysqlAccountPatchLineReviewStore extends JdbcAccountPatchLineReviewStore {
 
@@ -51,6 +58,12 @@ public class MysqlAccountPatchLineReviewStore extends JdbcAccountPatchLineReview
     }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>{@code file_name} is {@code VARCHAR(255)} so the full composite primary key fits within
+   * InnoDB index byte limits (for example with {@code utf8mb4}); other columns match the base DDL.
+   */
   @Override
   protected void doCreateTable(Statement stmt) throws SQLException {
     stmt.executeUpdate(

--- a/java/com/google/gerrit/server/schema/MysqlAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/MysqlAccountPatchLineReviewStore.java
@@ -65,6 +65,8 @@ public class MysqlAccountPatchLineReviewStore extends JdbcAccountPatchLineReview
             + "start_char INTEGER DEFAULT 0 NOT NULL, "
             + "end_line INTEGER DEFAULT 1 NOT NULL, "
             + "end_char INTEGER DEFAULT 0 NOT NULL, "
+            + "review_status SMALLINT DEFAULT 0 NOT NULL, "
+            + "tentative_carryover BOOLEAN DEFAULT FALSE NOT NULL, "
             + "CONSTRAINT primary_key_account_patch_line_reviews "
             + "PRIMARY KEY (change_id, patch_set_id, account_id, file_name, line_number, side, "
             + "start_line, start_char, end_line, end_char)"

--- a/java/com/google/gerrit/server/schema/PostgresqlAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/PostgresqlAccountPatchLineReviewStore.java
@@ -24,6 +24,14 @@ import com.google.inject.Singleton;
 import java.sql.SQLException;
 import org.eclipse.jgit.lib.Config;
 
+/**
+ * {@link JdbcAccountPatchLineReviewStore} for PostgreSQL.
+ *
+ * <p>{@link #convertError}: SQLSTATE {@code 23505} ({@code unique_violation}) becomes {@link
+ * DuplicateKeyException} for idempotent propagation. {@code 23514} (check), {@code 23503} (foreign
+ * key), {@code 23502} (not null), and {@code 23001} (restrict) are wrapped as {@link
+ * StorageException} with the same message path as other failures.
+ */
 @Singleton
 public class PostgresqlAccountPatchLineReviewStore extends JdbcAccountPatchLineReviewStore {
 

--- a/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
@@ -199,17 +199,6 @@ public class FakeAccountPatchLineReviewStore
     int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
     normalize(input, lineNumber, startLine, startChar, endLine, endChar);
 
-    LineEntity entity =
-        LineEntity.create(
-            psId,
-            accountId,
-            path,
-            lineNumber[0],
-            sideShort,
-            startLine[0],
-            startChar[0],
-            endLine[0],
-            endChar[0]);
     boolean added;
     synchronized (store) {
       Optional<LineEntity> existing =
@@ -224,42 +213,44 @@ public class FakeAccountPatchLineReviewStore
               endLine[0],
               endChar[0]);
       if (existing.isEmpty()) {
-        return store.add(
-            LineEntity.create(
-                psId,
-                accountId,
-                path,
-                lineNumber[0],
-                sideShort,
-                startLine[0],
-                startChar[0],
-                endLine[0],
-                endChar[0],
-                ReviewStatus.READ,
-                false));
+        added =
+            store.add(
+                LineEntity.create(
+                    psId,
+                    accountId,
+                    path,
+                    lineNumber[0],
+                    sideShort,
+                    startLine[0],
+                    startChar[0],
+                    endLine[0],
+                    endChar[0],
+                    ReviewStatus.READ,
+                    false));
+      } else {
+        LineEntity e = existing.get();
+        if (e.reviewStatus() == ReviewStatus.READ) {
+          added = false;
+        } else if (e.reviewStatus() == ReviewStatus.TENTATIVELY_READ) {
+          store.remove(e);
+          added =
+              store.add(
+                  LineEntity.create(
+                      psId,
+                      accountId,
+                      path,
+                      lineNumber[0],
+                      sideShort,
+                      startLine[0],
+                      startChar[0],
+                      endLine[0],
+                      endChar[0],
+                      ReviewStatus.READ,
+                      e.tentativeCarryover()));
+        } else {
+          added = false;
+        }
       }
-      LineEntity e = existing.get();
-      if (e.reviewStatus() == ReviewStatus.READ) {
-        return false;
-      }
-      if (e.reviewStatus() == ReviewStatus.TENTATIVELY_READ) {
-        store.remove(e);
-        return store.add(
-            LineEntity.create(
-                psId,
-                accountId,
-                path,
-                lineNumber[0],
-                sideShort,
-                startLine[0],
-                startChar[0],
-                endLine[0],
-                endChar[0],
-                ReviewStatus.READ,
-                e.tentativeCarryover()));
-      }
-      return false;
-      added = store.add(entity);
     }
     if (added) {
       synchronized (history) {
@@ -280,6 +271,9 @@ public class FakeAccountPatchLineReviewStore
       Account.Id accountId,
       String path,
       Collection<LineReviewedInput> inputs) {
+    if (inputs == null || inputs.isEmpty()) {
+      return;
+    }
     inputs.forEach(
         input -> {
           var unused = markLineReviewed(psId, accountId, path, input);
@@ -299,11 +293,7 @@ public class FakeAccountPatchLineReviewStore
     int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
     normalize(input, lineNumber, startLine, startChar, endLine, endChar);
 
-    LineEntity entity =
-        LineEntity.create(
-            psId, accountId, path, lineNumber[0], sideShort,
-            startLine[0], startChar[0], endLine[0], endChar[0]);
-    boolean removed;
+    boolean changed;
     synchronized (store) {
       Optional<LineEntity> existing =
           findEntity(
@@ -335,9 +325,10 @@ public class FakeAccountPatchLineReviewStore
                 endChar[0],
                 ReviewStatus.TENTATIVELY_READ,
                 true));
-      removed = store.remove(entity);
+      }
+      changed = true;
     }
-    if (removed) {
+    if (changed) {
       synchronized (history) {
         history.add(
             LineReviewHistoryEntry.create(
@@ -446,6 +437,7 @@ public class FakeAccountPatchLineReviewStore
   }
 
   /** Returns all matching lines for the account and patch set, optionally filtered to one path. */
+  @Override
   public ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> findAllReviewedLines(
       PatchSet.Id psId, String path) {
     synchronized (store) {
@@ -464,7 +456,8 @@ public class FakeAccountPatchLineReviewStore
                     entity.startLine(),
                     entity.startChar(),
                     entity.endLine(),
-                    entity.endChar()));
+                    entity.endChar(),
+                    entity.reviewStatus()));
       }
       ImmutableMap.Builder<Account.Id, ImmutableList<ReviewedLine>> result =
           ImmutableMap.builder();

--- a/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
@@ -36,12 +36,20 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * In-memory implementation of {@link AccountPatchLineReviewStore} for tests.
+ * In-memory {@link AccountPatchLineReviewStore} for acceptance and unit tests.
+ *
+ * <p>Behavior mirrors {@link com.google.gerrit.server.schema.JdbcAccountPatchLineReviewStore}:
+ * same normalization of {@link LineReviewedInput}, {@link ReviewStatus#READ} vs {@link
+ * ReviewStatus#TENTATIVELY_READ}, and {@code tentativeCarryover} semantics when clearing an explicit
+ * mark that originated from propagation. Data lives in a {@link HashSet} of {@link LineEntity}
+ * rows keyed implicitly by patch set, account, path, side, and line/character range; all access is
+ * {@code synchronized} on that set (no JDBC, no persistence across JVMs).
  */
 @Singleton
 public class FakeAccountPatchLineReviewStore
     implements AccountPatchLineReviewStore, LifecycleListener {
 
+  /** One entry per distinct reviewed region (same identity fields as the SQL primary key). */
   private final Set<LineEntity> store = new HashSet<>();
 
   @Override
@@ -50,6 +58,7 @@ public class FakeAccountPatchLineReviewStore
   @Override
   public void stop() {}
 
+  /** Guice module that binds {@link AccountPatchLineReviewStore} to this fake (test sites). */
   public static class FakeAccountPatchLineReviewStoreModule extends LifecycleModule {
     @Override
     protected void configure() {
@@ -59,6 +68,10 @@ public class FakeAccountPatchLineReviewStore
     }
   }
 
+  /**
+   * Internal row: patch set, account, file path, line/range geometry, review status, and whether
+   * the row was introduced by carryover propagation ({@code tentativeCarryover}).
+   */
   @AutoValue
   abstract static class LineEntity {
     abstract PatchSet.Id psId();
@@ -110,6 +123,10 @@ public class FakeAccountPatchLineReviewStore
     }
   }
 
+  /**
+   * Same rules as {@link com.google.gerrit.server.schema.JdbcAccountPatchLineReviewStore#normalizeInput}:
+   * derive {@code lineNumber} and inclusive range from REST input.
+   */
   private static void normalize(
       LineReviewedInput input,
       int[] lineNumber,
@@ -162,6 +179,10 @@ public class FakeAccountPatchLineReviewStore
     return Optional.empty();
   }
 
+  /**
+   * Inserts {@link ReviewStatus#READ} or upgrades {@link ReviewStatus#TENTATIVELY_READ} to {@code
+   * READ}, preserving {@code tentativeCarryover}. Returns whether the store changed.
+   */
   @Override
   public boolean markLineReviewed(
       PatchSet.Id psId, Account.Id accountId, String path, LineReviewedInput input) {
@@ -222,6 +243,7 @@ public class FakeAccountPatchLineReviewStore
     }
   }
 
+  /** Delegates to {@link #markLineReviewed(PatchSet.Id, Account.Id, String, LineReviewedInput)} per input. */
   @Override
   public void markLineReviewed(
       PatchSet.Id psId,
@@ -234,6 +256,10 @@ public class FakeAccountPatchLineReviewStore
         });
   }
 
+  /**
+   * Removes the row, or if it is {@link ReviewStatus#READ} with carryover provenance, replaces it
+   * with {@link ReviewStatus#TENTATIVELY_READ} so the propagated hint is not lost.
+   */
   @Override
   public void clearLineReviewed(
       PatchSet.Id psId, Account.Id accountId, String path, LineReviewedInput input) {
@@ -330,6 +356,10 @@ public class FakeAccountPatchLineReviewStore
     }
   }
 
+  /**
+   * Skips geometries that already exist; otherwise inserts {@link ReviewStatus#TENTATIVELY_READ}
+   * with carryover set (same as JDBC propagation path; no duplicate-key exceptions in-memory).
+   */
   @Override
   public void insertPropagatedTentativeReviews(
       PatchSet.Id psId, Account.Id accountId, Collection<ReviewedLine> lines) {
@@ -371,6 +401,7 @@ public class FakeAccountPatchLineReviewStore
     }
   }
 
+  /** Returns all matching lines for the account and patch set, optionally filtered to one path. */
   @Override
   public Optional<PatchSetWithReviewedLines> findReviewedLines(
       PatchSet.Id psId, Account.Id accountId, String path) {

--- a/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
@@ -20,6 +20,7 @@ import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
 import com.google.gerrit.extensions.api.changes.LineReviewedInput;
+import com.google.gerrit.extensions.client.ReviewStatus;
 import com.google.gerrit.extensions.client.Side;
 import com.google.gerrit.extensions.events.LifecycleListener;
 import com.google.gerrit.extensions.registration.DynamicItem;
@@ -77,6 +78,10 @@ public class FakeAccountPatchLineReviewStore
 
     abstract int endChar();
 
+    abstract ReviewStatus reviewStatus();
+
+    abstract boolean tentativeCarryover();
+
     static LineEntity create(
         PatchSet.Id psId,
         Account.Id accountId,
@@ -86,9 +91,21 @@ public class FakeAccountPatchLineReviewStore
         int startLine,
         int startChar,
         int endLine,
-        int endChar) {
+        int endChar,
+        ReviewStatus reviewStatus,
+        boolean tentativeCarryover) {
       return new AutoValue_FakeAccountPatchLineReviewStore_LineEntity(
-          psId, accountId, path, lineNumber, side, startLine, startChar, endLine, endChar);
+          psId,
+          accountId,
+          path,
+          lineNumber,
+          side,
+          startLine,
+          startChar,
+          endLine,
+          endChar,
+          reviewStatus,
+          tentativeCarryover);
     }
   }
 
@@ -117,6 +134,33 @@ public class FakeAccountPatchLineReviewStore
     }
   }
 
+  /** Caller must hold {@code synchronized (store)}. */
+  private Optional<LineEntity> findEntity(
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      int lineNumber,
+      short side,
+      int startLine,
+      int startChar,
+      int endLine,
+      int endChar) {
+    for (LineEntity e : store) {
+      if (e.psId().equals(psId)
+          && e.accountId().equals(accountId)
+          && e.path().equals(path)
+          && e.lineNumber() == lineNumber
+          && e.side() == side
+          && e.startLine() == startLine
+          && e.startChar() == startChar
+          && e.endLine() == endLine
+          && e.endChar() == endChar) {
+        return Optional.of(e);
+      }
+    }
+    return Optional.empty();
+  }
+
   @Override
   public boolean markLineReviewed(
       PatchSet.Id psId, Account.Id accountId, String path, LineReviewedInput input) {
@@ -127,8 +171,8 @@ public class FakeAccountPatchLineReviewStore
     normalize(input, lineNumber, startLine, startChar, endLine, endChar);
 
     synchronized (store) {
-      LineEntity entity =
-          LineEntity.create(
+      Optional<LineEntity> existing =
+          findEntity(
               psId,
               accountId,
               path,
@@ -138,7 +182,42 @@ public class FakeAccountPatchLineReviewStore
               startChar[0],
               endLine[0],
               endChar[0]);
-      return store.add(entity);
+      if (existing.isEmpty()) {
+        return store.add(
+            LineEntity.create(
+                psId,
+                accountId,
+                path,
+                lineNumber[0],
+                sideShort,
+                startLine[0],
+                startChar[0],
+                endLine[0],
+                endChar[0],
+                ReviewStatus.READ,
+                false));
+      }
+      LineEntity e = existing.get();
+      if (e.reviewStatus() == ReviewStatus.READ) {
+        return false;
+      }
+      if (e.reviewStatus() == ReviewStatus.TENTATIVELY_READ) {
+        store.remove(e);
+        return store.add(
+            LineEntity.create(
+                psId,
+                accountId,
+                path,
+                lineNumber[0],
+                sideShort,
+                startLine[0],
+                startChar[0],
+                endLine[0],
+                endChar[0],
+                ReviewStatus.READ,
+                e.tentativeCarryover()));
+      }
+      return false;
     }
   }
 
@@ -164,8 +243,8 @@ public class FakeAccountPatchLineReviewStore
     normalize(input, lineNumber, startLine, startChar, endLine, endChar);
 
     synchronized (store) {
-      store.remove(
-          LineEntity.create(
+      Optional<LineEntity> existing =
+          findEntity(
               psId,
               accountId,
               path,
@@ -174,7 +253,27 @@ public class FakeAccountPatchLineReviewStore
               startLine[0],
               startChar[0],
               endLine[0],
-              endChar[0]));
+              endChar[0]);
+      if (existing.isEmpty()) {
+        return;
+      }
+      LineEntity e = existing.get();
+      store.remove(e);
+      if (e.reviewStatus() == ReviewStatus.READ && e.tentativeCarryover()) {
+        store.add(
+            LineEntity.create(
+                psId,
+                accountId,
+                path,
+                lineNumber[0],
+                sideShort,
+                startLine[0],
+                startChar[0],
+                endLine[0],
+                endChar[0],
+                ReviewStatus.TENTATIVELY_READ,
+                true));
+      }
     }
   }
 
@@ -237,7 +336,8 @@ public class FakeAccountPatchLineReviewStore
                 entity.startLine(),
                 entity.startChar(),
                 entity.endLine(),
-                entity.endChar()));
+                entity.endChar(),
+                entity.reviewStatus()));
       }
       ImmutableList<ReviewedLine> lines = builder.build();
       if (lines.isEmpty()) {

--- a/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
@@ -16,6 +16,7 @@ package com.google.gerrit.testing;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
@@ -313,6 +314,60 @@ public class FakeAccountPatchLineReviewStore
         }
       }
       store.removeAll(toRemove);
+    }
+  }
+
+  @Override
+  public ImmutableSet<Account.Id> accountsWithLineReviews(PatchSet.Id psId) {
+    synchronized (store) {
+      ImmutableSet.Builder<Account.Id> b = ImmutableSet.builder();
+      for (LineEntity entity : store) {
+        if (entity.psId().equals(psId)) {
+          b.add(entity.accountId());
+        }
+      }
+      return b.build();
+    }
+  }
+
+  @Override
+  public void insertPropagatedTentativeReviews(
+      PatchSet.Id psId, Account.Id accountId, Collection<ReviewedLine> lines) {
+    if (lines == null || lines.isEmpty()) {
+      return;
+    }
+    synchronized (store) {
+      for (ReviewedLine line : lines) {
+        if (line == null) {
+          continue;
+        }
+        if (findEntity(
+                psId,
+                accountId,
+                line.path(),
+                line.lineNumber(),
+                line.side(),
+                line.startLine(),
+                line.startChar(),
+                line.endLine(),
+                line.endChar())
+            .isPresent()) {
+          continue;
+        }
+        store.add(
+            LineEntity.create(
+                psId,
+                accountId,
+                line.path(),
+                line.lineNumber(),
+                line.side(),
+                line.startLine(),
+                line.startChar(),
+                line.endLine(),
+                line.endChar(),
+                ReviewStatus.TENTATIVELY_READ,
+                true));
+      }
     }
   }
 

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -56,8 +56,6 @@ import com.google.gerrit.acceptance.testsuite.account.AccountOperations;
 import com.google.gerrit.acceptance.testsuite.change.ChangeOperations;
 import com.google.gerrit.acceptance.testsuite.project.ProjectOperations;
 import com.google.gerrit.acceptance.testsuite.request.RequestScopeOperations;
-import com.google.gerrit.acceptance.testsuite.project.ProjectOperations;
-import com.google.gerrit.acceptance.testsuite.request.RequestScopeOperations;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.BranchNameKey;
 import com.google.gerrit.entities.BranchOrderSection;

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -69,6 +69,7 @@ import com.google.gerrit.entities.Permission;
 import com.google.gerrit.entities.Project;
 import com.google.gerrit.entities.RefNames;
 import com.google.gerrit.extensions.api.changes.LineReviewedInput;
+import com.google.gerrit.extensions.client.ReviewStatus;
 import com.google.gerrit.extensions.client.Side;
 import com.google.gerrit.extensions.common.LineReviewedInfo;
 import com.google.gson.reflect.TypeToken;
@@ -1729,6 +1730,37 @@ public class RevisionIT extends AbstractDaemonTest {
         accountPatchLineReviewStore.findReviewedLines(
             r.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME);
     assertThat(found).isEmpty();
+  }
+
+  @Test
+  public void lineReviewsArePropagatedToNextPatchSetAsTentative() throws Exception {
+    PushOneCommit push =
+        pushFactory.create(
+            admin.newIdent(),
+            testRepo,
+            SUBJECT,
+            PushOneCommit.FILE_NAME,
+            "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+    PushOneCommit.Result r1 = push.to("refs/for/master");
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 5;
+    input.side = Side.REVISION;
+    var unused =
+        accountPatchLineReviewStore.markLineReviewed(
+            r1.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME, input);
+
+    // Insert two lines at the top so the previously reviewed line 5 moves to line 7.
+    PushOneCommit.Result r2 =
+        updateChange(r1, "new1\nnew2\nl1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+
+    Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> found =
+        accountPatchLineReviewStore.findReviewedLines(
+            r2.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME);
+    assertThat(found).isPresent();
+    assertThat(found.get().lines()).hasSize(1);
+    assertThat(found.get().lines().get(0).lineNumber()).isEqualTo(7);
+    assertThat(found.get().lines().get(0).reviewStatus()).isEqualTo(ReviewStatus.TENTATIVELY_READ);
   }
 
   // -- HTTP-level tests for the reviewed_lines REST endpoint --

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -1765,6 +1765,139 @@ public class RevisionIT extends AbstractDaemonTest {
     assertThat(found.get().lines().get(0).reviewStatus()).isEqualTo(ReviewStatus.TENTATIVELY_READ);
   }
 
+  @Test
+  public void lineReviewsPropagateIndependentlyForMultipleAccounts() throws Exception {
+    TestAccount reviewer2 = accountCreator.user2();
+    PushOneCommit push =
+        pushFactory.create(
+            admin.newIdent(),
+            testRepo,
+            SUBJECT,
+            PushOneCommit.FILE_NAME,
+            "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+    PushOneCommit.Result r1 = push.to("refs/for/master");
+
+    LineReviewedInput adminLine = new LineReviewedInput();
+    adminLine.line = 5;
+    adminLine.side = Side.REVISION;
+    var unused1 =
+        accountPatchLineReviewStore.markLineReviewed(
+            r1.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME, adminLine);
+
+    LineReviewedInput reviewer2Line = new LineReviewedInput();
+    reviewer2Line.line = 8;
+    reviewer2Line.side = Side.REVISION;
+    var unused2 =
+        accountPatchLineReviewStore.markLineReviewed(
+            r1.getPatchSetId(), reviewer2.id(), PushOneCommit.FILE_NAME, reviewer2Line);
+
+    // Insert one line at the top so line mappings shift by +1.
+    PushOneCommit.Result r2 = updateChange(r1, "new0\nl1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+
+    Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> adminFound =
+        accountPatchLineReviewStore.findReviewedLines(
+            r2.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME);
+    assertThat(adminFound).isPresent();
+    assertThat(adminFound.get().lines()).hasSize(1);
+    assertThat(adminFound.get().lines().get(0).lineNumber()).isEqualTo(6);
+    assertThat(adminFound.get().lines().get(0).reviewStatus())
+        .isEqualTo(ReviewStatus.TENTATIVELY_READ);
+
+    Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> reviewer2Found =
+        accountPatchLineReviewStore.findReviewedLines(
+            r2.getPatchSetId(), reviewer2.id(), PushOneCommit.FILE_NAME);
+    assertThat(reviewer2Found).isPresent();
+    assertThat(reviewer2Found.get().lines()).hasSize(1);
+    assertThat(reviewer2Found.get().lines().get(0).lineNumber()).isEqualTo(9);
+    assertThat(reviewer2Found.get().lines().get(0).reviewStatus())
+        .isEqualTo(ReviewStatus.TENTATIVELY_READ);
+  }
+
+  @Test
+  public void lineReviewIsDroppedWhenOriginalLineIsDeleted() throws Exception {
+    PushOneCommit push =
+        pushFactory.create(
+            admin.newIdent(), testRepo, SUBJECT, PushOneCommit.FILE_NAME, "l1\nl2\nl3\nl4\nl5\n");
+    PushOneCommit.Result r1 = push.to("refs/for/master");
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 5;
+    input.side = Side.REVISION;
+    var unused =
+        accountPatchLineReviewStore.markLineReviewed(
+            r1.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME, input);
+
+    // Remove the previously reviewed last line from the new patch set.
+    PushOneCommit.Result r2 = updateChange(r1, "l1\nl2\nl3\nl4\n");
+
+    Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> found =
+        accountPatchLineReviewStore.findReviewedLines(
+            r2.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME);
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  public void parentSideLineReviewIsNotPropagated() throws Exception {
+    PushOneCommit push =
+        pushFactory.create(
+            admin.newIdent(), testRepo, SUBJECT, PushOneCommit.FILE_NAME, "l1\nl2\nl3\nl4\nl5\n");
+    PushOneCommit.Result r1 = push.to("refs/for/master");
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 3;
+    input.side = Side.PARENT;
+    var unused =
+        accountPatchLineReviewStore.markLineReviewed(
+            r1.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME, input);
+
+    PushOneCommit.Result r2 = updateChange(r1, "new0\nl1\nl2\nl3\nl4\nl5\n");
+
+    Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> found =
+        accountPatchLineReviewStore.findReviewedLines(
+            r2.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME);
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  public void rangedLineReviewPropagatesAsTentative() throws Exception {
+    PushOneCommit push =
+        pushFactory.create(
+            admin.newIdent(),
+            testRepo,
+            SUBJECT,
+            PushOneCommit.FILE_NAME,
+            "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+    PushOneCommit.Result r1 = push.to("refs/for/master");
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 8;
+    input.side = Side.REVISION;
+    com.google.gerrit.extensions.client.Comment.Range range =
+        new com.google.gerrit.extensions.client.Comment.Range();
+    range.startLine = 6;
+    range.startCharacter = 1;
+    range.endLine = 8;
+    range.endCharacter = 4;
+    input.range = range;
+    var unused =
+        accountPatchLineReviewStore.markLineReviewed(
+            r1.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME, input);
+
+    PushOneCommit.Result r2 =
+        updateChange(r1, "new1\nnew2\nl1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+
+    Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> found =
+        accountPatchLineReviewStore.findReviewedLines(
+            r2.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME);
+    assertThat(found).isPresent();
+    assertThat(found.get().lines()).hasSize(1);
+    assertThat(found.get().lines().get(0).reviewStatus()).isEqualTo(ReviewStatus.TENTATIVELY_READ);
+    assertThat(found.get().lines().get(0).startLine()).isEqualTo(8);
+    assertThat(found.get().lines().get(0).endLine()).isEqualTo(10);
+    assertThat(found.get().lines().get(0).startChar()).isEqualTo(1);
+    assertThat(found.get().lines().get(0).endChar()).isEqualTo(4);
+  }
+
   // -- HTTP-level tests for the reviewed_lines REST endpoint --
 
   private String reviewedLinesUrl(String changeId) {

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -1757,6 +1757,8 @@ public class RevisionIT extends AbstractDaemonTest {
     Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> found =
         accountPatchLineReviewStore.findReviewedLines(
             r2.getPatchSetId(), admin.id(), PushOneCommit.FILE_NAME);
+    // Carryover is intentionally tentative: unchanged/mapped regions are pre-marked for reviewer
+    // convenience, but still distinguishable from explicit READ in this patch set.
     assertThat(found).isPresent();
     assertThat(found.get().lines()).hasSize(1);
     assertThat(found.get().lines().get(0).lineNumber()).isEqualTo(7);

--- a/javatests/com/google/gerrit/entities/converter/SafeProtoConverterTest.java
+++ b/javatests/com/google/gerrit/entities/converter/SafeProtoConverterTest.java
@@ -87,9 +87,14 @@ public class SafeProtoConverterTest {
           .filter(SafeProtoConverter.class::isAssignableFrom)
           .filter(clz -> !SafeProtoConverter.class.equals(clz))
           .filter(Class::isEnum)
-          .map(clz -> (SafeProtoConverter<Message, Object>) clz.getEnumConstants()[0])
+          .map(PerTypeSafeProtoConverterTest::firstConverterEnumConstant)
           .map(clz -> new Object[] {clz, clz.getClass().getSimpleName()})
           .collect(toImmutableList());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static SafeProtoConverter<Message, Object> firstConverterEnumConstant(Class<?> clz) {
+      return (SafeProtoConverter<Message, Object>) clz.getEnumConstants()[0];
     }
 
     /**

--- a/javatests/com/google/gerrit/server/change/LineReviewPropagationTest.java
+++ b/javatests/com/google/gerrit/server/change/LineReviewPropagationTest.java
@@ -142,6 +142,7 @@ public class LineReviewPropagationTest {
     verify(store).insertPropagatedTentativeReviews(eq(PS2), eq(ACCOUNT_ID), captor.capture());
     assertThat(captor.getValue()).hasSize(1);
     ReviewedLine propagated = captor.getValue().iterator().next();
+    // Geometry is remapped (5 -> 7) but status is downgraded to TENTATIVELY_READ on carryover.
     assertThat(propagated.path()).isEqualTo(FILE);
     assertThat(propagated.lineNumber()).isEqualTo(7);
     assertThat(propagated.reviewStatus()).isEqualTo(ReviewStatus.TENTATIVELY_READ);

--- a/javatests/com/google/gerrit/server/change/LineReviewPropagationTest.java
+++ b/javatests/com/google/gerrit/server/change/LineReviewPropagationTest.java
@@ -54,6 +54,10 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+/**
+ * Unit tests for {@link LineReviewPropagation}. Propagation is revision-side only; see {@code
+ * ignoresParentSideMarkers}.
+ */
 @RunWith(MockitoJUnitRunner.class)
 public class LineReviewPropagationTest {
   private static final Project.NameKey PROJECT = Project.nameKey("test");

--- a/javatests/com/google/gerrit/server/change/LineReviewPropagationTest.java
+++ b/javatests/com/google/gerrit/server/change/LineReviewPropagationTest.java
@@ -18,7 +18,9 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,6 +43,7 @@ import com.google.gerrit.server.patch.DiffOptions;
 import com.google.gerrit.server.patch.filediff.Edit;
 import com.google.gerrit.server.patch.filediff.FileDiffOutput;
 import com.google.gerrit.server.patch.filediff.TaggedEdit;
+import com.google.gerrit.server.plugincontext.PluginContext.ExtensionImplConsumer;
 import com.google.gerrit.server.plugincontext.PluginItemContext;
 import java.time.Instant;
 import java.util.Collection;
@@ -192,6 +195,214 @@ public class LineReviewPropagationTest {
     propagation.propagate(store, change, patchSet1, patchSet2);
 
     verify(store, never()).insertPropagatedTentativeReviews(any(), any(), any());
+  }
+
+  @Test
+  public void skipsWhenPatchSetsBelongToDifferentChanges() throws Exception {
+    PatchSet.Id otherPsId = PatchSet.id(Change.id(2), 2);
+    PatchSet otherPatchSet =
+        PatchSet.builder()
+            .id(otherPsId)
+            .commitId(NEW_COMMIT)
+            .uploader(Account.id(7))
+            .realUploader(Account.id(7))
+            .createdOn(Instant.now())
+            .build();
+
+    propagation.propagate(store, change, patchSet1, otherPatchSet);
+
+    verify(commentsUtil, never()).determineCommitId(any(), any(), anyShort());
+    verify(store, never()).accountsWithLineReviews(any());
+  }
+
+  @Test
+  public void skipsAccountWithoutPriorReviewedLines() throws Exception {
+    when(store.accountsWithLineReviews(PS1)).thenReturn(ImmutableSet.of(ACCOUNT_ID));
+    when(store.findReviewedLines(PS1, ACCOUNT_ID, null)).thenReturn(Optional.empty());
+    when(commentsUtil.determineCommitId(any(), any(), anyShort())).thenAnswer(this::commitForPatchSet);
+    when(diffOperations.listModifiedFiles(any(), any(), any(), any(DiffOptions.class)))
+        .thenReturn(ImmutableMap.of());
+
+    propagation.propagate(store, change, patchSet1, patchSet2);
+
+    verify(store, never()).insertPropagatedTentativeReviews(any(), any(), any());
+  }
+
+  @Test
+  public void skipsUnreadMarkers() throws Exception {
+    ReviewedLine unread =
+        ReviewedLine.create(FILE, 6, (short) 1, 6, 0, 6, 0, ReviewStatus.UNREAD);
+    when(store.accountsWithLineReviews(PS1)).thenReturn(ImmutableSet.of(ACCOUNT_ID));
+    when(store.findReviewedLines(PS1, ACCOUNT_ID, null))
+        .thenReturn(Optional.of(PatchSetWithReviewedLines.create(PS1, ImmutableList.of(unread))));
+    when(commentsUtil.determineCommitId(any(), any(), anyShort())).thenAnswer(this::commitForPatchSet);
+    when(diffOperations.listModifiedFiles(any(), any(), any(), any(DiffOptions.class)))
+        .thenReturn(ImmutableMap.of());
+
+    propagation.propagate(store, change, patchSet1, patchSet2);
+
+    verify(store, never()).insertPropagatedTentativeReviews(any(), any(), any());
+  }
+
+  @Test
+  public void propagatesRangeMarkerKeepingCharacterGeometry() throws Exception {
+    ReviewedLine range =
+        ReviewedLine.create(
+            FILE,
+            12,
+            (short) 1,
+            10,
+            2,
+            12,
+            5,
+            ReviewStatus.READ);
+    when(store.accountsWithLineReviews(PS1)).thenReturn(ImmutableSet.of(ACCOUNT_ID));
+    when(store.findReviewedLines(PS1, ACCOUNT_ID, null))
+        .thenReturn(Optional.of(PatchSetWithReviewedLines.create(PS1, ImmutableList.of(range))));
+    when(commentsUtil.determineCommitId(any(), any(), anyShort())).thenAnswer(this::commitForPatchSet);
+    when(diffOperations.listModifiedFiles(any(), any(), any(), any(DiffOptions.class)))
+        .thenReturn(
+            ImmutableMap.of(
+                FILE,
+                modifiedDiff(
+                    FILE,
+                    FILE,
+                    ImmutableList.of(
+                        // Insert two lines above the range start and end.
+                        TaggedEdit.create(Edit.create(0, 0, 0, 2), false)))));
+
+    propagation.propagate(store, change, patchSet1, patchSet2);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Collection<ReviewedLine>> captor =
+        (ArgumentCaptor<Collection<ReviewedLine>>) (ArgumentCaptor<?>) ArgumentCaptor.forClass(Collection.class);
+    verify(store, times(1)).insertPropagatedTentativeReviews(eq(PS2), eq(ACCOUNT_ID), captor.capture());
+    ReviewedLine propagated = captor.getValue().iterator().next();
+    assertThat(propagated.startLine()).isEqualTo(12);
+    assertThat(propagated.endLine()).isEqualTo(14);
+    assertThat(propagated.startChar()).isEqualTo(2);
+    assertThat(propagated.endChar()).isEqualTo(5);
+    assertThat(propagated.lineNumber()).isEqualTo(14);
+    assertThat(propagated.reviewStatus()).isEqualTo(ReviewStatus.TENTATIVELY_READ);
+  }
+
+  @Test
+  public void propagateOnNewPatchSet_runsInsidePluginContext() throws Exception {
+    ReviewedLine reviewed = ReviewedLine.create(FILE, 5, (short) 1, 5, 0, 5, 0, ReviewStatus.READ);
+    when(store.accountsWithLineReviews(PS1)).thenReturn(ImmutableSet.of(ACCOUNT_ID));
+    when(store.findReviewedLines(PS1, ACCOUNT_ID, null))
+        .thenReturn(Optional.of(PatchSetWithReviewedLines.create(PS1, ImmutableList.of(reviewed))));
+    when(commentsUtil.determineCommitId(any(), any(), anyShort())).thenAnswer(this::commitForPatchSet);
+    when(diffOperations.listModifiedFiles(any(), any(), any(), any(DiffOptions.class)))
+        .thenReturn(
+            ImmutableMap.of(
+                FILE,
+                modifiedDiff(
+                    FILE,
+                    FILE,
+                    ImmutableList.of(TaggedEdit.create(Edit.create(0, 0, 0, 1), false)))));
+    doAnswer(
+            invocation -> {
+              ExtensionImplConsumer<AccountPatchLineReviewStore> callback = invocation.getArgument(0);
+              callback.run(store);
+              return null;
+            })
+        .when(pluginItemContext)
+        .run(any());
+
+    propagation.propagateOnNewPatchSet(change, patchSet1, patchSet2);
+
+    verify(pluginItemContext, times(1)).run(any());
+    verify(store, times(1)).insertPropagatedTentativeReviews(any(), any(), any());
+  }
+
+  @Test
+  public void propagateOnNewPatchSet_swallowsPluginContextException() throws Exception {
+    when(commentsUtil.determineCommitId(any(), any(), anyShort())).thenAnswer(this::commitForPatchSet);
+    when(diffOperations.listModifiedFiles(any(), any(), any(), any(DiffOptions.class)))
+        .thenThrow(new RuntimeException("boom"));
+    doAnswer(
+            invocation -> {
+              ExtensionImplConsumer<AccountPatchLineReviewStore> callback = invocation.getArgument(0);
+              callback.run(store);
+              return null;
+            })
+        .when(pluginItemContext)
+        .run(any());
+
+    propagation.propagateOnNewPatchSet(change, patchSet1, patchSet2);
+
+    verify(pluginItemContext, times(1)).run(any());
+  }
+
+  @Test
+  public void propagatesPerAccountAndSkipsAccountWithoutMappedLines() throws Exception {
+    Account.Id otherAccount = Account.id(1002);
+    ReviewedLine account1Line =
+        ReviewedLine.create(FILE, 5, (short) 1, 5, 0, 5, 0, ReviewStatus.READ);
+    ReviewedLine account2ParentOnly =
+        ReviewedLine.create(FILE, 8, (short) 0, 8, 0, 8, 0, ReviewStatus.READ);
+    when(store.accountsWithLineReviews(PS1)).thenReturn(ImmutableSet.of(ACCOUNT_ID, otherAccount));
+    when(store.findReviewedLines(PS1, ACCOUNT_ID, null))
+        .thenReturn(Optional.of(PatchSetWithReviewedLines.create(PS1, ImmutableList.of(account1Line))));
+    when(store.findReviewedLines(PS1, otherAccount, null))
+        .thenReturn(Optional.of(PatchSetWithReviewedLines.create(PS1, ImmutableList.of(account2ParentOnly))));
+    when(commentsUtil.determineCommitId(any(), any(), anyShort())).thenAnswer(this::commitForPatchSet);
+    when(diffOperations.listModifiedFiles(any(), any(), any(), any(DiffOptions.class)))
+        .thenReturn(
+            ImmutableMap.of(
+                FILE,
+                modifiedDiff(
+                    FILE,
+                    FILE,
+                    ImmutableList.of(TaggedEdit.create(Edit.create(0, 0, 0, 1), false)))));
+
+    propagation.propagate(store, change, patchSet1, patchSet2);
+
+    verify(store, times(1)).insertPropagatedTentativeReviews(eq(PS2), eq(ACCOUNT_ID), any());
+    verify(store, never()).insertPropagatedTentativeReviews(eq(PS2), eq(otherAccount), any());
+  }
+
+  @Test
+  public void propagatesRangeEndingAtLineBoundary() throws Exception {
+    ReviewedLine rangeAtBoundary =
+        ReviewedLine.create(
+            FILE,
+            12,
+            (short) 1,
+            10,
+            0,
+            12,
+            0,
+            ReviewStatus.READ);
+    when(store.accountsWithLineReviews(PS1)).thenReturn(ImmutableSet.of(ACCOUNT_ID));
+    when(store.findReviewedLines(PS1, ACCOUNT_ID, null))
+        .thenReturn(
+            Optional.of(PatchSetWithReviewedLines.create(PS1, ImmutableList.of(rangeAtBoundary))));
+    when(commentsUtil.determineCommitId(any(), any(), anyShort())).thenAnswer(this::commitForPatchSet);
+    when(diffOperations.listModifiedFiles(any(), any(), any(), any(DiffOptions.class)))
+        .thenReturn(
+            ImmutableMap.of(
+                FILE,
+                modifiedDiff(
+                    FILE,
+                    FILE,
+                    ImmutableList.of(
+                        // shift by two lines
+                        TaggedEdit.create(Edit.create(0, 0, 0, 2), false)))));
+
+    propagation.propagate(store, change, patchSet1, patchSet2);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Collection<ReviewedLine>> captor =
+        (ArgumentCaptor<Collection<ReviewedLine>>) (ArgumentCaptor<?>) ArgumentCaptor.forClass(Collection.class);
+    verify(store).insertPropagatedTentativeReviews(eq(PS2), eq(ACCOUNT_ID), captor.capture());
+    ReviewedLine propagated = captor.getValue().iterator().next();
+    assertThat(propagated.startLine()).isEqualTo(12);
+    assertThat(propagated.endLine()).isEqualTo(14);
+    assertThat(propagated.startChar()).isEqualTo(0);
+    assertThat(propagated.endChar()).isEqualTo(0);
+    assertThat(propagated.lineNumber()).isEqualTo(14);
   }
 
   private static FileDiffOutput modifiedDiff(

--- a/javatests/com/google/gerrit/server/change/LineReviewPropagationTest.java
+++ b/javatests/com/google/gerrit/server/change/LineReviewPropagationTest.java
@@ -1,0 +1,218 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.change;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.gerrit.entities.Account;
+import com.google.gerrit.entities.BranchNameKey;
+import com.google.gerrit.entities.Change;
+import com.google.gerrit.entities.Patch;
+import com.google.gerrit.entities.PatchSet;
+import com.google.gerrit.entities.Project;
+import com.google.gerrit.extensions.client.ReviewStatus;
+import com.google.gerrit.server.CommentsUtil;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.PatchSetWithReviewedLines;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.ReviewedLine;
+import com.google.gerrit.server.patch.ComparisonType;
+import com.google.gerrit.server.patch.DiffOperations;
+import com.google.gerrit.server.patch.DiffOptions;
+import com.google.gerrit.server.patch.filediff.Edit;
+import com.google.gerrit.server.patch.filediff.FileDiffOutput;
+import com.google.gerrit.server.patch.filediff.TaggedEdit;
+import com.google.gerrit.server.plugincontext.PluginItemContext;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Optional;
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LineReviewPropagationTest {
+  private static final Project.NameKey PROJECT = Project.nameKey("test");
+  private static final Change.Id CHANGE_ID = Change.id(1);
+  private static final Account.Id ACCOUNT_ID = Account.id(1001);
+  private static final PatchSet.Id PS1 = PatchSet.id(CHANGE_ID, 1);
+  private static final PatchSet.Id PS2 = PatchSet.id(CHANGE_ID, 2);
+  private static final String FILE = "src/Main.java";
+
+  private static final ObjectId OLD_COMMIT =
+      ObjectId.fromString("1111111111111111111111111111111111111111");
+  private static final ObjectId NEW_COMMIT =
+      ObjectId.fromString("2222222222222222222222222222222222222222");
+
+  @Mock private PluginItemContext<AccountPatchLineReviewStore> pluginItemContext;
+  @Mock private DiffOperations diffOperations;
+  @Mock private CommentsUtil commentsUtil;
+  @Mock private AccountPatchLineReviewStore store;
+
+  private LineReviewPropagation propagation;
+  private Change change;
+  private PatchSet patchSet1;
+  private PatchSet patchSet2;
+
+  private Optional<ObjectId> commitForPatchSet(InvocationOnMock invocation) {
+    PatchSet patchSet = invocation.getArgument(1);
+    return patchSet.id().equals(PS1) ? Optional.of(OLD_COMMIT) : Optional.of(NEW_COMMIT);
+  }
+
+  @Before
+  public void setUp() {
+    propagation = new LineReviewPropagation(pluginItemContext, diffOperations, commentsUtil);
+    change =
+        new Change(
+            Change.key("I123"),
+            CHANGE_ID,
+            Account.id(7),
+            BranchNameKey.create(PROJECT, "refs/heads/main"),
+            Instant.now());
+    patchSet1 =
+        PatchSet.builder()
+            .id(PS1)
+            .commitId(OLD_COMMIT)
+            .uploader(Account.id(7))
+            .realUploader(Account.id(7))
+            .createdOn(Instant.now())
+            .build();
+    patchSet2 =
+        PatchSet.builder()
+            .id(PS2)
+            .commitId(NEW_COMMIT)
+            .uploader(Account.id(7))
+            .realUploader(Account.id(7))
+            .createdOn(Instant.now())
+            .build();
+  }
+
+  @Test
+  public void propagatesRevisionLineAsTentative() throws Exception {
+    ReviewedLine reviewed = ReviewedLine.create(FILE, 5, (short) 1, 5, 0, 5, 0, ReviewStatus.READ);
+    when(store.accountsWithLineReviews(PS1)).thenReturn(ImmutableSet.of(ACCOUNT_ID));
+    when(store.findReviewedLines(PS1, ACCOUNT_ID, null))
+        .thenReturn(Optional.of(PatchSetWithReviewedLines.create(PS1, ImmutableList.of(reviewed))));
+    when(commentsUtil.determineCommitId(any(), any(), anyShort()))
+        .thenAnswer(this::commitForPatchSet);
+    when(diffOperations.listModifiedFiles(any(), any(), any(), any(DiffOptions.class)))
+        .thenReturn(
+            ImmutableMap.of(
+                FILE,
+                modifiedDiff(
+                    FILE,
+                    FILE,
+                    ImmutableList.of(
+                        // Insert 2 lines at the top: old line 5 should map to new line 7.
+                        TaggedEdit.create(Edit.create(0, 0, 0, 2), false)))));
+
+    propagation.propagate(store, change, patchSet1, patchSet2);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Collection<ReviewedLine>> captor =
+        (ArgumentCaptor<Collection<ReviewedLine>>) (ArgumentCaptor<?>) ArgumentCaptor.forClass(Collection.class);
+    verify(store).insertPropagatedTentativeReviews(eq(PS2), eq(ACCOUNT_ID), captor.capture());
+    assertThat(captor.getValue()).hasSize(1);
+    ReviewedLine propagated = captor.getValue().iterator().next();
+    assertThat(propagated.path()).isEqualTo(FILE);
+    assertThat(propagated.lineNumber()).isEqualTo(7);
+    assertThat(propagated.reviewStatus()).isEqualTo(ReviewStatus.TENTATIVELY_READ);
+  }
+
+  @Test
+  public void ignoresParentSideMarkers() throws Exception {
+    ReviewedLine parentSide =
+        ReviewedLine.create(FILE, 8, (short) 0, 8, 0, 8, 0, ReviewStatus.READ);
+    when(store.accountsWithLineReviews(PS1)).thenReturn(ImmutableSet.of(ACCOUNT_ID));
+    when(store.findReviewedLines(PS1, ACCOUNT_ID, null))
+        .thenReturn(Optional.of(PatchSetWithReviewedLines.create(PS1, ImmutableList.of(parentSide))));
+    when(commentsUtil.determineCommitId(any(), any(), anyShort()))
+        .thenAnswer(this::commitForPatchSet);
+    when(diffOperations.listModifiedFiles(any(), any(), any(), any(DiffOptions.class)))
+        .thenReturn(ImmutableMap.of());
+
+    propagation.propagate(store, change, patchSet1, patchSet2);
+
+    verify(store, never()).insertPropagatedTentativeReviews(any(), any(), any());
+  }
+
+  @Test
+  public void skipsWhenCommitIdIsMissing() throws Exception {
+    when(commentsUtil.determineCommitId(any(), any(), anyShort())).thenReturn(Optional.empty());
+
+    propagation.propagate(store, change, patchSet1, patchSet2);
+
+    verify(store, never()).accountsWithLineReviews(any());
+    verify(store, never()).insertPropagatedTentativeReviews(any(), any(), any());
+  }
+
+  @Test
+  public void dropsMarkersWhenFileDeleted() throws Exception {
+    ReviewedLine reviewed = ReviewedLine.create(FILE, 4, (short) 1, 4, 0, 4, 0, ReviewStatus.READ);
+    when(store.accountsWithLineReviews(PS1)).thenReturn(ImmutableSet.of(ACCOUNT_ID));
+    when(store.findReviewedLines(PS1, ACCOUNT_ID, null))
+        .thenReturn(Optional.of(PatchSetWithReviewedLines.create(PS1, ImmutableList.of(reviewed))));
+    when(commentsUtil.determineCommitId(any(), any(), anyShort()))
+        .thenAnswer(this::commitForPatchSet);
+    when(diffOperations.listModifiedFiles(any(), any(), any(), any(DiffOptions.class)))
+        .thenReturn(
+            ImmutableMap.of(
+                FILE,
+                modifiedDiff(Optional.of(FILE), Optional.empty(), ImmutableList.of())));
+
+    propagation.propagate(store, change, patchSet1, patchSet2);
+
+    verify(store, never()).insertPropagatedTentativeReviews(any(), any(), any());
+  }
+
+  private static FileDiffOutput modifiedDiff(
+      String oldPath, String newPath, ImmutableList<TaggedEdit> edits) {
+    return modifiedDiff(Optional.of(oldPath), Optional.of(newPath), edits);
+  }
+
+  private static FileDiffOutput modifiedDiff(
+      Optional<String> oldPath, Optional<String> newPath, ImmutableList<TaggedEdit> edits) {
+    return FileDiffOutput.builder()
+        .oldCommitId(OLD_COMMIT)
+        .newCommitId(NEW_COMMIT)
+        .comparisonType(ComparisonType.againstOtherPatchSet())
+        .oldPath(oldPath)
+        .newPath(newPath)
+        .oldMode(Optional.of(Patch.FileMode.REGULAR_FILE))
+        .newMode(Optional.of(Patch.FileMode.REGULAR_FILE))
+        .oldSha(Optional.of(OLD_COMMIT))
+        .newSha(Optional.of(NEW_COMMIT))
+        .changeType(Patch.ChangeType.MODIFIED)
+        .patchType(Optional.empty())
+        .headerLines(ImmutableList.of())
+        .edits(edits)
+        .size(0L)
+        .sizeDelta(0L)
+        .negative(Optional.empty())
+        .build();
+  }
+}

--- a/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
+++ b/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
@@ -26,7 +26,6 @@ import com.google.gerrit.extensions.api.changes.LineReviewedInput;
 import com.google.gerrit.extensions.client.Comment.Range;
 import com.google.gerrit.extensions.client.ReviewStatus;
 import com.google.gerrit.extensions.client.Side;
-import com.google.common.collect.ImmutableList;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore.LineReviewAction;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore.LineReviewHistoryEntry;
@@ -335,6 +334,8 @@ public class JdbcAccountPatchLineReviewStoreTest {
     store.insertPropagatedTentativeReviews(PS_1, ACCOUNT_1, ImmutableList.of(line));
 
     assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, null).get().lines()).hasSize(1);
+  }
+
   // -- tests for findAllReviewedLines --
 
   @Test

--- a/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
+++ b/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
@@ -21,12 +21,14 @@ import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
 import com.google.gerrit.extensions.api.changes.LineReviewedInput;
 import com.google.gerrit.extensions.client.Comment.Range;
+import com.google.gerrit.extensions.client.ReviewStatus;
 import com.google.gerrit.extensions.client.Side;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore.PatchSetWithReviewedLines;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore.ReviewedLine;
 import java.sql.Connection;
 import java.sql.Statement;
+import java.util.Locale;
 import java.util.Optional;
 import org.junit.After;
 import org.junit.Before;
@@ -93,6 +95,40 @@ public class JdbcAccountPatchLineReviewStoreTest {
     return input;
   }
 
+  private void insertReviewedRow(
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      int line,
+      ReviewStatus status,
+      boolean tentativeCarryover)
+      throws Exception {
+
+    try (Connection con = store.getConnection();
+        Statement stmt = con.createStatement()) {
+      String sql =
+          String.format(
+              Locale.US,
+              "INSERT INTO account_patch_line_reviews "
+                  + "(account_id, change_id, patch_set_id, file_name, line_number, side, "
+                  + "start_line, start_char, end_line, end_char, review_status, tentative_carryover) "
+                  + "VALUES (%d, %d, %d, '%s', %d, %d, %d, %d, %d, %d, %d, %s)",
+              accountId.get(),
+              psId.changeId().get(),
+              psId.get(),
+              path,
+              line,
+              /* side=REVISION */ 1,
+              line,
+              0,
+              line,
+              0,
+              status.toDbValue(),
+              tentativeCarryover ? "TRUE" : "FALSE");
+      stmt.executeUpdate(sql);
+    }
+  }
+
   // -- tests --
 
   @Test
@@ -107,6 +143,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
     assertThat(line.lineNumber()).isEqualTo(5);
     assertThat(line.path()).isEqualTo(FILE_A);
     assertThat(line.getSide()).isEqualTo(Side.REVISION);
+    assertThat(line.reviewStatus()).isEqualTo(ReviewStatus.READ);
   }
 
   @Test
@@ -225,5 +262,32 @@ public class JdbcAccountPatchLineReviewStoreTest {
 
     assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A)).isEmpty();
     assertThat(store.findReviewedLines(PS_1, ACCOUNT_2, FILE_A)).isPresent();
+  }
+
+  @Test
+  public void clearReadRestoresTentativeWhenCarryover() throws Exception {
+    insertReviewedRow(PS_1, ACCOUNT_1, FILE_A, 5, ReviewStatus.TENTATIVELY_READ, true);
+
+    boolean upgraded = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+    assertThat(upgraded).isTrue();
+    assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A).get().lines().get(0).reviewStatus())
+        .isEqualTo(ReviewStatus.READ);
+
+    store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+
+    Optional<PatchSetWithReviewedLines> after = store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A);
+    assertThat(after).isPresent();
+    assertThat(after.get().lines()).hasSize(1);
+    assertThat(after.get().lines().get(0).reviewStatus())
+        .isEqualTo(ReviewStatus.TENTATIVELY_READ);
+  }
+
+  @Test
+  public void clearTentativeRowRemovesLine() throws Exception {
+    insertReviewedRow(PS_1, ACCOUNT_1, FILE_A, 7, ReviewStatus.TENTATIVELY_READ, true);
+
+    store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(7));
+
+    assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A)).isEmpty();
   }
 }

--- a/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
+++ b/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
@@ -268,6 +268,8 @@ public class JdbcAccountPatchLineReviewStoreTest {
 
   @Test
   public void clearReadRestoresTentativeWhenCarryover() throws Exception {
+    // Simulate a propagated row (tentative + carryover=true), then verify explicit read and clear
+    // transitions: TENTATIVELY_READ -> READ -> TENTATIVELY_READ.
     insertReviewedRow(PS_1, ACCOUNT_1, FILE_A, 5, ReviewStatus.TENTATIVELY_READ, true);
 
     boolean upgraded = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
@@ -314,6 +316,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
         store.findReviewedLines(PS_2, ACCOUNT_1, FILE_A);
     assertThat(found).isPresent();
     ReviewedLine stored = found.get().lines().get(0);
+    // JDBC insertion ignores incoming status and persists propagated rows as tentative carryover.
     assertThat(stored.reviewStatus()).isEqualTo(ReviewStatus.TENTATIVELY_READ);
     assertThat(stored.lineNumber()).isEqualTo(4);
   }

--- a/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
+++ b/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
@@ -16,6 +16,8 @@ package com.google.gerrit.server.schema;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
@@ -289,5 +291,41 @@ public class JdbcAccountPatchLineReviewStoreTest {
     store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(7));
 
     assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A)).isEmpty();
+  }
+
+  @Test
+  public void accountsWithLineReviews_returnsDistinctAccounts() {
+    var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+    var unused2 = store.markLineReviewed(PS_1, ACCOUNT_2, FILE_B, lineInput(2));
+
+    assertThat(store.accountsWithLineReviews(PS_1))
+        .containsExactlyElementsIn(ImmutableSet.of(ACCOUNT_1, ACCOUNT_2));
+    assertThat(store.accountsWithLineReviews(PS_2)).isEmpty();
+  }
+
+  @Test
+  public void insertPropagatedTentativeReviews_insertsTentativeWithCarryover() {
+    ReviewedLine line =
+        ReviewedLine.create(
+            FILE_A, 4, (short) 1, 4, 0, 4, 0, ReviewStatus.READ);
+    store.insertPropagatedTentativeReviews(PS_2, ACCOUNT_1, ImmutableList.of(line));
+
+    Optional<PatchSetWithReviewedLines> found =
+        store.findReviewedLines(PS_2, ACCOUNT_1, FILE_A);
+    assertThat(found).isPresent();
+    ReviewedLine stored = found.get().lines().get(0);
+    assertThat(stored.reviewStatus()).isEqualTo(ReviewStatus.TENTATIVELY_READ);
+    assertThat(stored.lineNumber()).isEqualTo(4);
+  }
+
+  @Test
+  public void insertPropagatedTentativeReviews_skipsExistingKey() {
+    ReviewedLine line =
+        ReviewedLine.create(
+            FILE_A, 4, (short) 1, 4, 0, 4, 0, ReviewStatus.TENTATIVELY_READ);
+    store.insertPropagatedTentativeReviews(PS_1, ACCOUNT_1, ImmutableList.of(line));
+    store.insertPropagatedTentativeReviews(PS_1, ACCOUNT_1, ImmutableList.of(line));
+
+    assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, null).get().lines()).hasSize(1);
   }
 }

--- a/lib/highlightjs/rollup.config.js
+++ b/lib/highlightjs/rollup.config.js
@@ -78,7 +78,12 @@ export default {
   },
   plugins: [
     nodeResolve({
-      modulePaths: [path.join(process.cwd(), 'external/ui_npm/node_modules')]
+      modulePaths: [path.join(process.cwd(), 'external/ui_npm/node_modules')],
+      // highlight.js v11+ "exports" maps "import" to ./es/*. Rollup then walks the whole es/ tree,
+      // but rules_nodejs does not expose every nested file as a Bazel input ("missing input file"
+      // under @@ui_npm). Prefer the "require" branch (./lib/*.js, CommonJS). List "import" after
+      // "require" so dual packages use lib/, while ESM-only dependencies can still resolve.
+      exportConditions: ['require', 'import', 'node', 'default'],
     }),
     cjs(),
   ]


### PR DESCRIPTION
- Use LineReviewPropagation service to map previous markers onto the new patch set (propagate read status as tentatively read)
- Adjust storage schema and add new store operations to support propagated line markers
- Add unit tests, JDBC tests, acceptance tests for propagation logic (LineReviewPropagationTest, RevisionIT)