### PR TITLE
Add backend functionality for summary of progress per file for all reviewers

### DIFF
--- a/java/com/google/gerrit/extensions/common/FileLineReviewProgressInfo.java
+++ b/java/com/google/gerrit/extensions/common/FileLineReviewProgressInfo.java
@@ -19,6 +19,10 @@ import java.util.List;
 /**
  * Per-file line review progress: whole-file line count as the denominator, and one entry per
  * reviewer who has stored line-review data on this patch set.
+ *
+ * <p>Overall fields ({@link #percentRead}, {@link #percentTentativelyRead}, {@link #percentUnread})
+ * are computed from merged line markers across reviewers (any-reviewer coverage), not from
+ * averaging the per-reviewer percentages.
  */
 public class FileLineReviewProgressInfo {
   /** Total lines in the file at this revision (denominator for the percentages below). */
@@ -33,8 +37,9 @@ public class FileLineReviewProgressInfo {
    */
   public Double percentTentativelyRead;
 
-  /** Overall percent of file lines not marked READ/TENTATIVELY_READ. */
+  /** Overall percent of file lines with no READ/TENTATIVELY_READ marker from any reviewer. */
   public Double percentUnread;
 
+  /** Per-reviewer progress for each account that has stored line-review markers on this patch set. */
   public List<ReviewerLineReviewProgressInfo> reviewers;
 }

--- a/java/com/google/gerrit/extensions/common/FileLineReviewProgressInfo.java
+++ b/java/com/google/gerrit/extensions/common/FileLineReviewProgressInfo.java
@@ -24,16 +24,16 @@ public class FileLineReviewProgressInfo {
   /** Total lines in the file at this revision (denominator for the percentages below). */
   public Integer totalLinesInFile;
 
-  /** Overall percent of file lines marked READ by all reviewers. */
+  /** Overall percent of file lines marked READ by at least one reviewer. */
   public Double percentRead;
 
   /**
    * Overall percent of file lines marked TENTATIVELY_READ by at least one reviewer, excluding
-   * lines already marked READ by all reviewers.
+   * lines already marked READ by at least one reviewer.
    */
   public Double percentTentativelyRead;
 
-  /** Overall percent of file lines not marked READ/TENTATIVELY_READ by at least one reviewer. */
+  /** Overall percent of file lines not marked READ/TENTATIVELY_READ. */
   public Double percentUnread;
 
   public List<ReviewerLineReviewProgressInfo> reviewers;

--- a/java/com/google/gerrit/extensions/common/FileLineReviewProgressInfo.java
+++ b/java/com/google/gerrit/extensions/common/FileLineReviewProgressInfo.java
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.List;
+
+/**
+ * Per-file line review progress: whole-file line count as the denominator, and one entry per
+ * reviewer who has stored line-review data on this patch set.
+ */
+public class FileLineReviewProgressInfo {
+  /** Total lines in the file at this revision (denominator for the percentages below). */
+  public Integer totalLinesInFile;
+
+  public List<ReviewerLineReviewProgressInfo> reviewers;
+}

--- a/java/com/google/gerrit/extensions/common/FileLineReviewProgressInfo.java
+++ b/java/com/google/gerrit/extensions/common/FileLineReviewProgressInfo.java
@@ -24,5 +24,17 @@ public class FileLineReviewProgressInfo {
   /** Total lines in the file at this revision (denominator for the percentages below). */
   public Integer totalLinesInFile;
 
+  /** Overall percent of file lines marked READ by any reviewer. */
+  public Double percentRead;
+
+  /**
+   * Overall percent of file lines marked TENTATIVELY_READ by any reviewer, excluding lines already
+   * marked READ by any reviewer.
+   */
+  public Double percentTentativelyRead;
+
+  /** Overall percent of file lines not marked READ/TENTATIVELY_READ by any reviewer. */
+  public Double percentUnread;
+
   public List<ReviewerLineReviewProgressInfo> reviewers;
 }

--- a/java/com/google/gerrit/extensions/common/FileLineReviewProgressInfo.java
+++ b/java/com/google/gerrit/extensions/common/FileLineReviewProgressInfo.java
@@ -24,16 +24,16 @@ public class FileLineReviewProgressInfo {
   /** Total lines in the file at this revision (denominator for the percentages below). */
   public Integer totalLinesInFile;
 
-  /** Overall percent of file lines marked READ by any reviewer. */
+  /** Overall percent of file lines marked READ by all reviewers. */
   public Double percentRead;
 
   /**
-   * Overall percent of file lines marked TENTATIVELY_READ by any reviewer, excluding lines already
-   * marked READ by any reviewer.
+   * Overall percent of file lines marked TENTATIVELY_READ by at least one reviewer, excluding
+   * lines already marked READ by all reviewers.
    */
   public Double percentTentativelyRead;
 
-  /** Overall percent of file lines not marked READ/TENTATIVELY_READ by any reviewer. */
+  /** Overall percent of file lines not marked READ/TENTATIVELY_READ by at least one reviewer. */
   public Double percentUnread;
 
   public List<ReviewerLineReviewProgressInfo> reviewers;

--- a/java/com/google/gerrit/extensions/common/ReviewerLineReviewProgressInfo.java
+++ b/java/com/google/gerrit/extensions/common/ReviewerLineReviewProgressInfo.java
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+/**
+ * Progress of reviewer on a file, as a percentage of total lines in the file at the
+ * revision.
+ */
+public class ReviewerLineReviewProgressInfo {
+  public AccountInfo account;
+
+  /** Percentage of lines marked read ({@code READ}) on the revision side. */
+  public Double percentRead;
+
+  /** Percentage of lines tentatively read ({@code TENTATIVELY_READ}), excluding lines also read. */
+  public Double percentTentativelyRead;
+
+  /** Percentage of lines with no marker on the revision side. */
+  public Double percentUnread;
+}

--- a/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
@@ -169,6 +169,9 @@ public interface AccountPatchLineReviewStore {
   /**
    * Accounts that have at least one line review row stored for the given patch set.
    *
+   * <p>Used by {@code /line_review_progress} to enumerate reviewers that contribute per-reviewer
+   * and overall file progress.
+   *
    * @param psId patch set ID
    */
   default ImmutableSet<Account.Id> accountsWithLineReviews(PatchSet.Id psId) {

--- a/java/com/google/gerrit/server/change/FileLineReviewProgressComputer.java
+++ b/java/com/google/gerrit/server/change/FileLineReviewProgressComputer.java
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.change;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Range;
+import com.google.common.collect.TreeRangeSet;
+import com.google.gerrit.extensions.client.ReviewStatus;
+import com.google.gerrit.extensions.client.Side;
+
+/** Computes read / tentative / unread line counts for one file from stored markers. */
+public final class FileLineReviewProgressComputer {
+
+  public static final class Counts {
+    public final int readLines;
+    public final int tentativelyReadLines;
+    public final int unreadLines;
+
+    Counts(int readLines, int tentativelyReadLines, int unreadLines) {
+      this.readLines = readLines;
+      this.tentativelyReadLines = tentativelyReadLines;
+      this.unreadLines = unreadLines;
+    }
+  }
+
+  /**
+   * Counts lines on the {@link Side#REVISION} side only. Tentative coverage excludes lines that are
+   * also covered by an explicit {@link ReviewStatus#READ} marker.
+   */
+  public static Counts compute(
+      ImmutableList<AccountPatchLineReviewStore.ReviewedLine> lines, int totalLinesInFile) {
+    if (totalLinesInFile <= 0) {
+      return new Counts(0, 0, 0);
+    }
+    TreeRangeSet<Integer> readRanges = TreeRangeSet.create();
+    TreeRangeSet<Integer> tentRanges = TreeRangeSet.create();
+    for (AccountPatchLineReviewStore.ReviewedLine line : lines) {
+      if (line.getSide() != Side.REVISION) {
+        continue;
+      }
+      int lo = Math.min(line.startLine(), line.endLine());
+      int hi = Math.max(line.startLine(), line.endLine());
+      if (hi < 1) {
+        continue;
+      }
+      lo = Math.max(lo, 1);
+      hi = Math.min(hi, totalLinesInFile);
+      if (lo > hi) {
+        continue;
+      }
+      Range<Integer> span = Range.closed(lo, hi);
+      if (line.reviewStatus() == ReviewStatus.READ) {
+        readRanges.add(span);
+      } else if (line.reviewStatus() == ReviewStatus.TENTATIVELY_READ) {
+        tentRanges.add(span);
+      }
+    }
+    TreeRangeSet<Integer> tentOnly = TreeRangeSet.create(tentRanges);
+    tentOnly.removeAll(readRanges);
+
+    int readCount = countLines(readRanges, totalLinesInFile);
+    int tentCount = countLines(tentOnly, totalLinesInFile);
+    int unread = totalLinesInFile - readCount - tentCount;
+    return new Counts(readCount, tentCount, unread);
+  }
+
+  private static int countLines(TreeRangeSet<Integer> rs, int totalLinesInFile) {
+    Range<Integer> fileSpan = Range.closed(1, totalLinesInFile);
+    int n = 0;
+    for (Range<Integer> r : rs.subRangeSet(fileSpan).asRanges()) {
+      Range<Integer> clipped = r.intersection(fileSpan);
+      if (!clipped.isEmpty()) {
+        n += clipped.upperEndpoint() - clipped.lowerEndpoint() + 1;
+      }
+    }
+    return n;
+  }
+
+  private FileLineReviewProgressComputer() {}
+}

--- a/java/com/google/gerrit/server/change/RevisionFileLineCounts.java
+++ b/java/com/google/gerrit/server/change/RevisionFileLineCounts.java
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.change;
+
+import com.google.gerrit.entities.Patch;
+import com.google.gerrit.entities.Project;
+import com.google.gerrit.server.git.GitRepositoryManager;
+import com.google.gerrit.server.patch.ComparisonType;
+import com.google.gerrit.server.patch.Text;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.io.IOException;
+import org.eclipse.jgit.errors.LargeObjectException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectLoader;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.treewalk.TreeWalk;
+
+/** Line counts for files at a revision, using the same text model as diff and content APIs. */
+@Singleton
+public class RevisionFileLineCounts {
+  private final GitRepositoryManager repoManager;
+
+  @Inject
+  RevisionFileLineCounts(GitRepositoryManager repoManager) {
+    this.repoManager = repoManager;
+  }
+
+  /**
+   * Returns the number of lines in the file at the given commit. Magic paths use generated text;
+   * missing paths and non-blob entries return 0.
+   */
+  public int countLines(Project.NameKey project, ObjectId commitId, String path)
+      throws IOException {
+    if (Patch.PATCHSET_LEVEL.equals(path)) {
+      return 0;
+    }
+    try (Repository repo = repoManager.openRepository(project);
+        RevWalk rw = new RevWalk(repo)) {
+      RevCommit commit = rw.parseCommit(commitId);
+      if (Patch.COMMIT_MSG.equals(path)) {
+        return Text.forCommit(rw.getObjectReader(), commit).size();
+      }
+      if (Patch.MERGE_LIST.equals(path)) {
+        return Text.forMergeList(
+                ComparisonType.againstAutoMerge(), rw.getObjectReader(), commit)
+            .size();
+      }
+      try (TreeWalk tw = TreeWalk.forPath(rw.getObjectReader(), path, commit.getTree())) {
+        if (tw == null) {
+          return 0;
+        }
+        if (tw.getFileMode(0).getObjectType() == Constants.OBJ_TREE) {
+          return 0;
+        }
+        if (tw.getFileMode(0) == org.eclipse.jgit.lib.FileMode.GITLINK) {
+          return 0;
+        }
+        ObjectLoader loader = repo.open(tw.getObjectId(0), Constants.OBJ_BLOB);
+        try {
+          return new Text(Text.asByteArray(loader)).size();
+        } catch (LargeObjectException e) {
+          return 0;
+        }
+      }
+    }
+  }
+}

--- a/java/com/google/gerrit/server/restapi/change/ChangeRestApiModule.java
+++ b/java/com/google/gerrit/server/restapi/change/ChangeRestApiModule.java
@@ -161,6 +161,7 @@ public class ChangeRestApiModule extends RestApiModule {
     get(FILE_KIND, "reviewed_lines").to(ReviewedLines.GetReviewedLines.class);
     put(FILE_KIND, "reviewed_lines").to(ReviewedLines.PutReviewedLine.class);
     delete(FILE_KIND, "reviewed_lines").to(ReviewedLines.DeleteReviewedLine.class);
+    get(FILE_KIND, "line_review_progress").to(GetFileLineReviewProgress.class);
 
     child(REVISION_KIND, "fixes").to(Fixes.class);
     post(FIX_KIND, "apply").to(ApplyStoredFix.class);

--- a/java/com/google/gerrit/server/restapi/change/GetFileLineReviewProgress.java
+++ b/java/com/google/gerrit/server/restapi/change/GetFileLineReviewProgress.java
@@ -77,7 +77,8 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
 
     AccountLoader loader = accountLoaderFactory.create(true);
     List<ReviewerLineReviewProgressInfo> reviewers = new ArrayList<>();
-    ImmutableList.Builder<FileLineReviewProgressComputer.Counts> reviewerCounts = ImmutableList.builder();
+    ImmutableList.Builder<AccountPatchLineReviewStore.ReviewedLine> allReviewedLines =
+        ImmutableList.builder();
     for (Account.Id accountId : sorted) {
       Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> opt =
           accountPatchLineReviewStore.call(s -> s.findReviewedLines(psId, accountId, path));
@@ -86,7 +87,7 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
               .orElseGet(ImmutableList::of);
       FileLineReviewProgressComputer.Counts counts =
           FileLineReviewProgressComputer.compute(lines, totalLines);
-      reviewerCounts.add(counts);
+      allReviewedLines.addAll(lines);
 
       ReviewerLineReviewProgressInfo info = new ReviewerLineReviewProgressInfo();
       info.account = loader.get(accountId);
@@ -95,32 +96,14 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
     }
     loader.fill();
 
-    OverallCounts overallCounts = computeOverallCounts(reviewerCounts.build(), totalLines);
+    FileLineReviewProgressComputer.Counts overallCounts =
+        FileLineReviewProgressComputer.compute(allReviewedLines.build(), totalLines);
 
     FileLineReviewProgressInfo out = new FileLineReviewProgressInfo();
     out.totalLinesInFile = totalLines;
     fillPercents(out, overallCounts, totalLines);
     out.reviewers = reviewers;
     return Response.ok(out);
-  }
-
-  private static OverallCounts computeOverallCounts(
-      ImmutableList<FileLineReviewProgressComputer.Counts> reviewerCounts, int totalLinesInFile) {
-    if (totalLinesInFile <= 0) {
-      return new OverallCounts(0, 0, 0);
-    }
-    if (reviewerCounts.isEmpty()) {
-      return new OverallCounts(0, 0, totalLinesInFile);
-    }
-
-    int readLines = totalLinesInFile;
-    int unreadLines = 0;
-    for (FileLineReviewProgressComputer.Counts counts : reviewerCounts) {
-      readLines = Math.min(readLines, counts.readLines);
-      unreadLines = Math.max(unreadLines, counts.unreadLines);
-    }
-    int tentativelyReadLines = totalLinesInFile - readLines - unreadLines;
-    return new OverallCounts(readLines, Math.max(0, tentativelyReadLines), unreadLines);
   }
 
   private static void fillPercents(
@@ -140,7 +123,7 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
 
   private static void fillPercents(
       FileLineReviewProgressInfo info,
-      OverallCounts counts,
+      FileLineReviewProgressComputer.Counts counts,
       int totalLinesInFile) {
     if (totalLinesInFile <= 0) {
       info.percentRead = null;
@@ -151,17 +134,5 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
     info.percentRead = 100.0 * counts.readLines / totalLinesInFile;
     info.percentTentativelyRead = 100.0 * counts.tentativelyReadLines / totalLinesInFile;
     info.percentUnread = 100.0 * counts.unreadLines / totalLinesInFile;
-  }
-
-  private static class OverallCounts {
-    final int readLines;
-    final int tentativelyReadLines;
-    final int unreadLines;
-
-    OverallCounts(int readLines, int tentativelyReadLines, int unreadLines) {
-      this.readLines = readLines;
-      this.tentativelyReadLines = tentativelyReadLines;
-      this.unreadLines = unreadLines;
-    }
   }
 }

--- a/java/com/google/gerrit/server/restapi/change/GetFileLineReviewProgress.java
+++ b/java/com/google/gerrit/server/restapi/change/GetFileLineReviewProgress.java
@@ -40,9 +40,9 @@ import java.util.Optional;
 /**
  * GET {@code /changes/{id}/revisions/{rev}/files/{file}/line_review_progress}
  *
- * <p>Whole-file line count is the denominator; each reviewer with line-review rows on this patch
- * set gets {@code percentRead}, {@code percentTentativelyRead}, and {@code percentUnread} for this
- * file.
+ * <p>Whole-file line count is the denominator. The response includes overall file progress across
+ * all reviewers plus per-reviewer percentages for each account with line-review rows on this patch
+ * set.
  */
 @Singleton
 public class GetFileLineReviewProgress implements RestReadView<FileResource> {
@@ -77,12 +77,15 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
 
     AccountLoader loader = accountLoaderFactory.create(true);
     List<ReviewerLineReviewProgressInfo> reviewers = new ArrayList<>();
+    ImmutableList.Builder<AccountPatchLineReviewStore.ReviewedLine> allReviewerLines =
+        ImmutableList.builder();
     for (Account.Id accountId : sorted) {
       Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> opt =
           accountPatchLineReviewStore.call(s -> s.findReviewedLines(psId, accountId, path));
       ImmutableList<AccountPatchLineReviewStore.ReviewedLine> lines =
           opt.map(AccountPatchLineReviewStore.PatchSetWithReviewedLines::lines)
               .orElseGet(ImmutableList::of);
+      allReviewerLines.addAll(lines);
       FileLineReviewProgressComputer.Counts counts =
           FileLineReviewProgressComputer.compute(lines, totalLines);
 
@@ -93,14 +96,33 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
     }
     loader.fill();
 
+    FileLineReviewProgressComputer.Counts overallCounts =
+        FileLineReviewProgressComputer.compute(allReviewerLines.build(), totalLines);
+
     FileLineReviewProgressInfo out = new FileLineReviewProgressInfo();
     out.totalLinesInFile = totalLines;
+    fillPercents(out, overallCounts, totalLines);
     out.reviewers = reviewers;
     return Response.ok(out);
   }
 
   private static void fillPercents(
       ReviewerLineReviewProgressInfo info,
+      FileLineReviewProgressComputer.Counts counts,
+      int totalLinesInFile) {
+    if (totalLinesInFile <= 0) {
+      info.percentRead = null;
+      info.percentTentativelyRead = null;
+      info.percentUnread = null;
+      return;
+    }
+    info.percentRead = 100.0 * counts.readLines / totalLinesInFile;
+    info.percentTentativelyRead = 100.0 * counts.tentativelyReadLines / totalLinesInFile;
+    info.percentUnread = 100.0 * counts.unreadLines / totalLinesInFile;
+  }
+
+  private static void fillPercents(
+      FileLineReviewProgressInfo info,
       FileLineReviewProgressComputer.Counts counts,
       int totalLinesInFile) {
     if (totalLinesInFile <= 0) {

--- a/java/com/google/gerrit/server/restapi/change/GetFileLineReviewProgress.java
+++ b/java/com/google/gerrit/server/restapi/change/GetFileLineReviewProgress.java
@@ -42,7 +42,8 @@ import java.util.Optional;
  *
  * <p>Whole-file line count is the denominator. The response includes overall file progress across
  * all reviewers plus per-reviewer percentages for each account with line-review rows on this patch
- * set.
+ * set. Overall values use any-reviewer coverage: if any reviewer marks a line READ, that line
+ * contributes to overall READ.
  */
 @Singleton
 public class GetFileLineReviewProgress implements RestReadView<FileResource> {
@@ -77,6 +78,7 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
 
     AccountLoader loader = accountLoaderFactory.create(true);
     List<ReviewerLineReviewProgressInfo> reviewers = new ArrayList<>();
+    // Build one merged line-marker list so overall progress reflects coverage by any reviewer.
     ImmutableList.Builder<AccountPatchLineReviewStore.ReviewedLine> allReviewedLines =
         ImmutableList.builder();
     for (Account.Id accountId : sorted) {
@@ -87,6 +89,7 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
               .orElseGet(ImmutableList::of);
       FileLineReviewProgressComputer.Counts counts =
           FileLineReviewProgressComputer.compute(lines, totalLines);
+      // Preserve all raw markers; the computer handles side filtering, overlaps and deduplication.
       allReviewedLines.addAll(lines);
 
       ReviewerLineReviewProgressInfo info = new ReviewerLineReviewProgressInfo();
@@ -110,6 +113,7 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
       ReviewerLineReviewProgressInfo info,
       FileLineReviewProgressComputer.Counts counts,
       int totalLinesInFile) {
+    // Keep percentages null when denominator is undefined/empty.
     if (totalLinesInFile <= 0) {
       info.percentRead = null;
       info.percentTentativelyRead = null;
@@ -125,6 +129,7 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
       FileLineReviewProgressInfo info,
       FileLineReviewProgressComputer.Counts counts,
       int totalLinesInFile) {
+    // Keep percentages null when denominator is undefined/empty.
     if (totalLinesInFile <= 0) {
       info.percentRead = null;
       info.percentTentativelyRead = null;

--- a/java/com/google/gerrit/server/restapi/change/GetFileLineReviewProgress.java
+++ b/java/com/google/gerrit/server/restapi/change/GetFileLineReviewProgress.java
@@ -77,17 +77,16 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
 
     AccountLoader loader = accountLoaderFactory.create(true);
     List<ReviewerLineReviewProgressInfo> reviewers = new ArrayList<>();
-    ImmutableList.Builder<AccountPatchLineReviewStore.ReviewedLine> allReviewerLines =
-        ImmutableList.builder();
+    ImmutableList.Builder<FileLineReviewProgressComputer.Counts> reviewerCounts = ImmutableList.builder();
     for (Account.Id accountId : sorted) {
       Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> opt =
           accountPatchLineReviewStore.call(s -> s.findReviewedLines(psId, accountId, path));
       ImmutableList<AccountPatchLineReviewStore.ReviewedLine> lines =
           opt.map(AccountPatchLineReviewStore.PatchSetWithReviewedLines::lines)
               .orElseGet(ImmutableList::of);
-      allReviewerLines.addAll(lines);
       FileLineReviewProgressComputer.Counts counts =
           FileLineReviewProgressComputer.compute(lines, totalLines);
+      reviewerCounts.add(counts);
 
       ReviewerLineReviewProgressInfo info = new ReviewerLineReviewProgressInfo();
       info.account = loader.get(accountId);
@@ -96,14 +95,32 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
     }
     loader.fill();
 
-    FileLineReviewProgressComputer.Counts overallCounts =
-        FileLineReviewProgressComputer.compute(allReviewerLines.build(), totalLines);
+    OverallCounts overallCounts = computeOverallCounts(reviewerCounts.build(), totalLines);
 
     FileLineReviewProgressInfo out = new FileLineReviewProgressInfo();
     out.totalLinesInFile = totalLines;
     fillPercents(out, overallCounts, totalLines);
     out.reviewers = reviewers;
     return Response.ok(out);
+  }
+
+  private static OverallCounts computeOverallCounts(
+      ImmutableList<FileLineReviewProgressComputer.Counts> reviewerCounts, int totalLinesInFile) {
+    if (totalLinesInFile <= 0) {
+      return new OverallCounts(0, 0, 0);
+    }
+    if (reviewerCounts.isEmpty()) {
+      return new OverallCounts(0, 0, totalLinesInFile);
+    }
+
+    int readLines = totalLinesInFile;
+    int unreadLines = 0;
+    for (FileLineReviewProgressComputer.Counts counts : reviewerCounts) {
+      readLines = Math.min(readLines, counts.readLines);
+      unreadLines = Math.max(unreadLines, counts.unreadLines);
+    }
+    int tentativelyReadLines = totalLinesInFile - readLines - unreadLines;
+    return new OverallCounts(readLines, Math.max(0, tentativelyReadLines), unreadLines);
   }
 
   private static void fillPercents(
@@ -123,7 +140,7 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
 
   private static void fillPercents(
       FileLineReviewProgressInfo info,
-      FileLineReviewProgressComputer.Counts counts,
+      OverallCounts counts,
       int totalLinesInFile) {
     if (totalLinesInFile <= 0) {
       info.percentRead = null;
@@ -134,5 +151,17 @@ public class GetFileLineReviewProgress implements RestReadView<FileResource> {
     info.percentRead = 100.0 * counts.readLines / totalLinesInFile;
     info.percentTentativelyRead = 100.0 * counts.tentativelyReadLines / totalLinesInFile;
     info.percentUnread = 100.0 * counts.unreadLines / totalLinesInFile;
+  }
+
+  private static class OverallCounts {
+    final int readLines;
+    final int tentativelyReadLines;
+    final int unreadLines;
+
+    OverallCounts(int readLines, int tentativelyReadLines, int unreadLines) {
+      this.readLines = readLines;
+      this.tentativelyReadLines = tentativelyReadLines;
+      this.unreadLines = unreadLines;
+    }
   }
 }

--- a/java/com/google/gerrit/server/restapi/change/GetFileLineReviewProgress.java
+++ b/java/com/google/gerrit/server/restapi/change/GetFileLineReviewProgress.java
@@ -1,0 +1,116 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.restapi.change;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.gerrit.entities.Account;
+import com.google.gerrit.extensions.common.FileLineReviewProgressInfo;
+import com.google.gerrit.extensions.common.ReviewerLineReviewProgressInfo;
+import com.google.gerrit.extensions.restapi.Response;
+import com.google.gerrit.extensions.restapi.RestReadView;
+import com.google.gerrit.server.account.AccountLoader;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore;
+import com.google.gerrit.server.change.FileLineReviewProgressComputer;
+import com.google.gerrit.server.change.FileResource;
+import com.google.gerrit.server.change.RevisionFileLineCounts;
+import com.google.gerrit.server.permissions.PermissionBackendException;
+import com.google.gerrit.server.plugincontext.PluginItemContext;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * GET {@code /changes/{id}/revisions/{rev}/files/{file}/line_review_progress}
+ *
+ * <p>Whole-file line count is the denominator; each reviewer with line-review rows on this patch
+ * set gets {@code percentRead}, {@code percentTentativelyRead}, and {@code percentUnread} for this
+ * file.
+ */
+@Singleton
+public class GetFileLineReviewProgress implements RestReadView<FileResource> {
+  private final PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore;
+  private final RevisionFileLineCounts revisionFileLineCounts;
+  private final AccountLoader.Factory accountLoaderFactory;
+
+  @Inject
+  GetFileLineReviewProgress(
+      PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore,
+      RevisionFileLineCounts revisionFileLineCounts,
+      AccountLoader.Factory accountLoaderFactory) {
+    this.accountPatchLineReviewStore = accountPatchLineReviewStore;
+    this.revisionFileLineCounts = revisionFileLineCounts;
+    this.accountLoaderFactory = accountLoaderFactory;
+  }
+
+  @Override
+  public Response<FileLineReviewProgressInfo> apply(FileResource rsrc)
+      throws IOException, PermissionBackendException {
+    var key = rsrc.getPatchKey();
+    String path = key.fileName();
+    var psId = key.patchSetId();
+    var rev = rsrc.getRevision();
+
+    int totalLines =
+        revisionFileLineCounts.countLines(rev.getProject(), rev.getPatchSet().commitId(), path);
+
+    ImmutableSet<Account.Id> accountIds =
+        accountPatchLineReviewStore.call(s -> s.accountsWithLineReviews(psId));
+    ImmutableList<Account.Id> sorted = accountIds.stream().sorted().collect(toImmutableList());
+
+    AccountLoader loader = accountLoaderFactory.create(true);
+    List<ReviewerLineReviewProgressInfo> reviewers = new ArrayList<>();
+    for (Account.Id accountId : sorted) {
+      Optional<AccountPatchLineReviewStore.PatchSetWithReviewedLines> opt =
+          accountPatchLineReviewStore.call(s -> s.findReviewedLines(psId, accountId, path));
+      ImmutableList<AccountPatchLineReviewStore.ReviewedLine> lines =
+          opt.map(AccountPatchLineReviewStore.PatchSetWithReviewedLines::lines)
+              .orElseGet(ImmutableList::of);
+      FileLineReviewProgressComputer.Counts counts =
+          FileLineReviewProgressComputer.compute(lines, totalLines);
+
+      ReviewerLineReviewProgressInfo info = new ReviewerLineReviewProgressInfo();
+      info.account = loader.get(accountId);
+      fillPercents(info, counts, totalLines);
+      reviewers.add(info);
+    }
+    loader.fill();
+
+    FileLineReviewProgressInfo out = new FileLineReviewProgressInfo();
+    out.totalLinesInFile = totalLines;
+    out.reviewers = reviewers;
+    return Response.ok(out);
+  }
+
+  private static void fillPercents(
+      ReviewerLineReviewProgressInfo info,
+      FileLineReviewProgressComputer.Counts counts,
+      int totalLinesInFile) {
+    if (totalLinesInFile <= 0) {
+      info.percentRead = null;
+      info.percentTentativelyRead = null;
+      info.percentUnread = null;
+      return;
+    }
+    info.percentRead = 100.0 * counts.readLines / totalLinesInFile;
+    info.percentTentativelyRead = 100.0 * counts.tentativelyReadLines / totalLinesInFile;
+    info.percentUnread = 100.0 * counts.unreadLines / totalLinesInFile;
+  }
+}

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -554,133 +554,153 @@ public abstract class JdbcAccountPatchLineReviewStore
       return;
     }
     for (LineReviewedInput input : inputs) {
-      markLineReviewed(psId, accountId, path, input);
+      var unused = markLineReviewed(psId, accountId, path, input);
     }
   }
 
   @Override
   public void clearLineReviewed(
-    PatchSet.Id psId, Account.Id accountId, String path, LineReviewedInput input) {
-  Side side = input.side != null ? input.side : Side.REVISION;
-  int[] lineNumber = new int[1];
-  int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
-  normalizeInput(input, lineNumber, startLine, startChar, endLine, endChar);
-  short sideShort = sideToShort(side);
+      PatchSet.Id psId, Account.Id accountId, String path, LineReviewedInput input) {
+    Side side = input.side != null ? input.side : Side.REVISION;
+    int[] lineNumber = new int[1];
+    int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
+    normalizeInput(input, lineNumber, startLine, startChar, endLine, endChar);
+    short sideShort = sideToShort(side);
 
-  try (TraceTimer ignored =
-          TraceContext.newTimer(
-              "Clear line/region reviewed flag",
-              Metadata.builder()
-                  .patchSetId(psId.get())
-                  .accountId(accountId.get())
-                  .filePath(path)
-                  .build());
-      Connection con = ds.getConnection()) {
-    boolean prevAutoCommit = con.getAutoCommit();
-    // Select-then-update/delete must be atomic for correct carryover downgrade vs delete.
-    con.setAutoCommit(false);
-    try {
-      boolean changed =
-          clearLineReviewedInTransaction(
-              con,
-              psId,
-              accountId,
-              path,
-              lineNumber[0],
-              sideShort,
-              startLine[0],
-              startChar[0],
-              endLine[0],
-              endChar[0]);
-      con.commit();
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "Clear line/region reviewed flag",
+                Metadata.builder()
+                    .patchSetId(psId.get())
+                    .accountId(accountId.get())
+                    .filePath(path)
+                    .build());
+        Connection con = ds.getConnection()) {
+      boolean prevAutoCommit = con.getAutoCommit();
+      // Select-then-update/delete must be atomic for correct carryover downgrade vs delete.
+      con.setAutoCommit(false);
+      try {
+        boolean changed =
+            clearLineReviewedInTransaction(
+                con,
+                psId,
+                accountId,
+                path,
+                lineNumber[0],
+                sideShort,
+                startLine[0],
+                startChar[0],
+                endLine[0],
+                endChar[0]);
+        con.commit();
 
-      if (changed) {
-        try {
-          insertHistoryEntry(
-              con,
-              psId,
-              accountId,
-              path,
-              lineNumber[0],
-              sideShort,
-              startLine[0],
-              startChar[0],
-              endLine[0],
-              endChar[0],
-              LineReviewAction.UNMARKED);
-        } catch (SQLException e) {
-          logger.atWarning().withCause(e).log("Failed to log UNMARKED action to history");
+        if (changed) {
+          try {
+            insertHistoryEntry(
+                con,
+                psId,
+                accountId,
+                path,
+                lineNumber[0],
+                sideShort,
+                startLine[0],
+                startChar[0],
+                endLine[0],
+                endChar[0],
+                LineReviewAction.UNMARKED);
+          } catch (SQLException e) {
+            logger.atWarning().withCause(e).log("Failed to log UNMARKED action to history");
+          }
         }
+      } catch (SQLException e) {
+        con.rollback();
+        throw convertError("clearLineReviewed", e);
+      } finally {
+        con.setAutoCommit(prevAutoCommit);
       }
     } catch (SQLException e) {
-      con.rollback();
       throw convertError("clearLineReviewed", e);
-    } finally {
-      con.setAutoCommit(prevAutoCommit);
     }
-  } catch (SQLException e) {
-    throw convertError("clearLineReviewed", e);
   }
-}
 
   /**
    * If the row is {@link ReviewStatus#READ} with {@code tentative_carryover}, downgrade to {@link
    * ReviewStatus#TENTATIVELY_READ}; otherwise delete the row (unread or dismissing tentative).
    */
   private boolean clearLineReviewedInTransaction(
-    Connection con,
-    PatchSet.Id psId,
-    Account.Id accountId,
-    String path,
-    int lineNumber,
-    short side,
-    int startLine,
-    int startChar,
-    int endLine,
-    int endChar)
-    throws SQLException {
-  String select =
-      "SELECT review_status, tentative_carryover FROM account_patch_line_reviews WHERE "
-          + "account_id = ? AND change_id = ? AND patch_set_id = ? AND file_name = ? "
-          + "AND line_number = ? AND side = ? AND start_line = ? AND start_char = ? "
-          + "AND end_line = ? AND end_char = ?";
-  try (PreparedStatement sel = con.prepareStatement(select)) {
-    bindLineGeometry(
-        sel, 1, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
-    try (ResultSet rs = sel.executeQuery()) {
-      if (!rs.next()) {
-        return false;
-      }
-
-      ReviewStatus current = ReviewStatus.fromDbValue(rs.getShort(1));
-      boolean carry = rs.getBoolean(2);
-
-      if (current == ReviewStatus.READ && carry) {
-        try (PreparedStatement upd =
-            con.prepareStatement(
-                "UPDATE account_patch_line_reviews SET review_status = ? WHERE "
-                    + "account_id = ? AND change_id = ? AND patch_set_id = ? AND file_name = ? "
-                    + "AND line_number = ? AND side = ? AND start_line = ? AND start_char = ? "
-                    + "AND end_line = ? AND end_char = ?")) {
-          upd.setShort(1, ReviewStatus.TENTATIVELY_READ.toDbValue());
-          bindLineGeometry(
-              upd, 2, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
-          return upd.executeUpdate() > 0;
+      Connection con,
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      int lineNumber,
+      short side,
+      int startLine,
+      int startChar,
+      int endLine,
+      int endChar)
+      throws SQLException {
+    String select =
+        "SELECT review_status, tentative_carryover FROM account_patch_line_reviews WHERE "
+            + "account_id = ? AND change_id = ? AND patch_set_id = ? AND file_name = ? "
+            + "AND line_number = ? AND side = ? AND start_line = ? AND start_char = ? "
+            + "AND end_line = ? AND end_char = ?";
+    try (PreparedStatement sel = con.prepareStatement(select)) {
+      bindLineGeometry(
+          sel, 1, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
+      try (ResultSet rs = sel.executeQuery()) {
+        if (!rs.next()) {
+          return false;
         }
-      }
 
-      try (PreparedStatement del =
-          con.prepareStatement(
-              "DELETE FROM account_patch_line_reviews WHERE account_id = ? AND change_id = ? "
-                  + "AND patch_set_id = ? AND file_name = ? AND line_number = ? AND side = ? "
-                  + "AND start_line = ? AND start_char = ? AND end_line = ? AND end_char = ?")) {
-        bindLineGeometry(
-            del, 1, accountId, psId, path, lineNumber, side, startLine, startChar, endLine, endChar);
-        return del.executeUpdate() > 0;
+        ReviewStatus current = ReviewStatus.fromDbValue(rs.getShort(1));
+        boolean carry = rs.getBoolean(2);
+
+        if (current == ReviewStatus.READ && carry) {
+          try (PreparedStatement upd =
+              con.prepareStatement(
+                  "UPDATE account_patch_line_reviews SET review_status = ? WHERE "
+                      + "account_id = ? AND change_id = ? AND patch_set_id = ? AND file_name = ? "
+                      + "AND line_number = ? AND side = ? AND start_line = ? AND start_char = ? "
+                      + "AND end_line = ? AND end_char = ?")) {
+            upd.setShort(1, ReviewStatus.TENTATIVELY_READ.toDbValue());
+            bindLineGeometry(
+                upd,
+                2,
+                accountId,
+                psId,
+                path,
+                lineNumber,
+                side,
+                startLine,
+                startChar,
+                endLine,
+                endChar);
+            return upd.executeUpdate() > 0;
+          }
+        }
+
+        try (PreparedStatement del =
+            con.prepareStatement(
+                "DELETE FROM account_patch_line_reviews WHERE account_id = ? AND change_id = ? "
+                    + "AND patch_set_id = ? AND file_name = ? AND line_number = ? AND side = ? "
+                    + "AND start_line = ? AND start_char = ? AND end_line = ? AND end_char = ?")) {
+          bindLineGeometry(
+              del,
+              1,
+              accountId,
+              psId,
+              path,
+              lineNumber,
+              side,
+              startLine,
+              startChar,
+              endLine,
+              endChar);
+          return del.executeUpdate() > 0;
+        }
       }
     }
   }
-}
 
   @Override
   public void clearLineReviewed(PatchSet.Id psId) {

--- a/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
@@ -283,7 +283,10 @@ public boolean markLineReviewed(
     if (inputs == null || inputs.isEmpty()) {
       return;
     }
-    inputs.forEach(input -> markLineReviewed(psId, accountId, path, input));
+    inputs.forEach(
+        input -> {
+          var unused = markLineReviewed(psId, accountId, path, input);
+        });
   }
 
   /**
@@ -331,7 +334,6 @@ public boolean markLineReviewed(
                 endChar[0],
                 ReviewStatus.TENTATIVELY_READ,
                 true));
-      removed = store.remove(entity);
       }
       changed = true;
     }

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -1802,6 +1802,51 @@ public class RevisionIT extends AbstractDaemonTest {
     assertThat(a.percentRead).isWithin(0.001).of(10.0);
     assertThat(a.percentTentativelyRead).isWithin(0.001).of(0.0);
     assertThat(a.percentUnread).isWithin(0.001).of(90.0);
+    assertThat(progress.percentRead).isWithin(0.001).of(10.0);
+    assertThat(progress.percentTentativelyRead).isWithin(0.001).of(0.0);
+    assertThat(progress.percentUnread).isWithin(0.001).of(90.0);
+  }
+
+  @Test
+  public void getFileLineReviewProgress_overallProgressUsesAnyReviewerCoverage()
+      throws Exception {
+    PushOneCommit.Result r =
+        createChange(SUBJECT, FILE_NAME, "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+
+    LineReviewedInput adminInput = new LineReviewedInput();
+    adminInput.line = 2;
+    adminInput.side = Side.REVISION;
+    adminRestSession.put(reviewedLinesUrl(r.getChangeId()), adminInput).assertCreated();
+
+    LineReviewedInput userInput = new LineReviewedInput();
+    userInput.line = 9;
+    userInput.side = Side.REVISION;
+    userRestSession.put(reviewedLinesUrl(r.getChangeId()), userInput).assertCreated();
+
+    RestResponse getResp =
+        adminRestSession.get(fileLineReviewProgressUrl(r.getChangeId(), FILE_NAME));
+    getResp.assertOK();
+    FileLineReviewProgressInfo progress =
+        newGson()
+            .fromJson(
+                getResp.getReader(), new TypeToken<FileLineReviewProgressInfo>() {}.getType());
+    assertThat(progress.totalLinesInFile).isEqualTo(10);
+    assertThat(progress.percentRead).isWithin(0.001).of(20.0);
+    assertThat(progress.percentTentativelyRead).isWithin(0.001).of(0.0);
+    assertThat(progress.percentUnread).isWithin(0.001).of(80.0);
+    assertThat(progress.reviewers).hasSize(2);
+
+    Double adminRead = null;
+    Double userRead = null;
+    for (ReviewerLineReviewProgressInfo reviewer : progress.reviewers) {
+      if (reviewer.account._accountId == admin.id().get()) {
+        adminRead = reviewer.percentRead;
+      } else if (reviewer.account._accountId == user.id().get()) {
+        userRead = reviewer.percentRead;
+      }
+    }
+    assertThat(adminRead).isWithin(0.001).of(10.0);
+    assertThat(userRead).isWithin(0.001).of(10.0);
   }
 
   @Test
@@ -1902,6 +1947,34 @@ public class RevisionIT extends AbstractDaemonTest {
     assertThat(a.percentRead).isWithin(0.001).of(100.0);
     assertThat(a.percentTentativelyRead).isWithin(0.001).of(0.0);
     assertThat(a.percentUnread).isWithin(0.001).of(0.0);
+  }
+
+  @Test
+  public void getFileLineReviewProgress_is100WhenAnyReviewerCoverageIsComplete() throws Exception {
+    PushOneCommit.Result r = createChange(SUBJECT, FILE_NAME, "r1\nr2\nr3\n");
+    String url = reviewedLinesUrl(r.getChangeId());
+    for (int line = 1; line <= 3; line++) {
+      LineReviewedInput input = new LineReviewedInput();
+      input.line = line;
+      input.side = Side.REVISION;
+      adminRestSession.put(url, input).assertCreated();
+    }
+
+    LineReviewedInput userInput = new LineReviewedInput();
+    userInput.line = 1;
+    userInput.side = Side.REVISION;
+    userRestSession.put(url, userInput).assertCreated();
+
+    RestResponse getResp =
+        adminRestSession.get(fileLineReviewProgressUrl(r.getChangeId(), FILE_NAME));
+    getResp.assertOK();
+    FileLineReviewProgressInfo progress =
+        newGson()
+            .fromJson(
+                getResp.getReader(), new TypeToken<FileLineReviewProgressInfo>() {}.getType());
+
+    assertThat(progress.percentRead).isWithin(0.001).of(100.0);
+    assertThat(progress.percentUnread).isWithin(0.001).of(0.0);
   }
 
   @Test

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -1768,7 +1768,11 @@ public class RevisionIT extends AbstractDaemonTest {
   // -- HTTP-level tests for the reviewed_lines REST endpoint --
 
   private String reviewedLinesUrl(String changeId) {
-    return "/changes/" + changeId + "/revisions/current/files/" + FILE_NAME + "/reviewed_lines";
+    return reviewedLinesUrl(changeId, FILE_NAME);
+  }
+
+  private String reviewedLinesUrl(String changeId, String fileName) {
+    return "/changes/" + changeId + "/revisions/current/files/" + fileName + "/reviewed_lines";
   }
 
   private String fileLineReviewProgressUrl(String changeId, String fileName) {
@@ -1872,6 +1876,62 @@ public class RevisionIT extends AbstractDaemonTest {
     assertThat(a.percentRead).isWithin(0.001).of(0.0);
     assertThat(a.percentTentativelyRead).isWithin(0.001).of(100.0 / 12.0);
     assertThat(a.percentUnread).isWithin(0.001).of(100.0 * 11 / 12);
+  }
+
+  @Test
+  public void getFileLineReviewProgress_fullyReviewedFile_percentReadIs100() throws Exception {
+    PushOneCommit.Result r = createChange(SUBJECT, FILE_NAME, "r1\nr2\nr3\n");
+    String url = reviewedLinesUrl(r.getChangeId());
+    for (int line = 1; line <= 3; line++) {
+      LineReviewedInput input = new LineReviewedInput();
+      input.line = line;
+      input.side = Side.REVISION;
+      adminRestSession.put(url, input).assertCreated();
+    }
+
+    RestResponse getResp =
+        adminRestSession.get(fileLineReviewProgressUrl(r.getChangeId(), FILE_NAME));
+    getResp.assertOK();
+    FileLineReviewProgressInfo progress =
+        newGson()
+            .fromJson(
+                getResp.getReader(), new TypeToken<FileLineReviewProgressInfo>() {}.getType());
+    assertThat(progress.totalLinesInFile).isEqualTo(3);
+    assertThat(progress.reviewers).hasSize(1);
+    ReviewerLineReviewProgressInfo a = progress.reviewers.get(0);
+    assertThat(a.percentRead).isWithin(0.001).of(100.0);
+    assertThat(a.percentTentativelyRead).isWithin(0.001).of(0.0);
+    assertThat(a.percentUnread).isWithin(0.001).of(0.0);
+  }
+
+  @Test
+  public void getFileLineReviewProgress_unreviewedFile_percentReadIsZero() throws Exception {
+    String fiveLines = "l1\nl2\nl3\nl4\nl5\n";
+    PushOneCommit push =
+        pushFactory.create(
+            admin.newIdent(),
+            testRepo,
+            SUBJECT,
+            ImmutableMap.of(FILE_NAME, fiveLines, "b.txt", fiveLines));
+    PushOneCommit.Result r = push.to("refs/for/master");
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 1;
+    input.side = Side.REVISION;
+    adminRestSession.put(reviewedLinesUrl(r.getChangeId(), FILE_NAME), input).assertCreated();
+
+    RestResponse getResp =
+        adminRestSession.get(fileLineReviewProgressUrl(r.getChangeId(), "b.txt"));
+    getResp.assertOK();
+    FileLineReviewProgressInfo progress =
+        newGson()
+            .fromJson(
+                getResp.getReader(), new TypeToken<FileLineReviewProgressInfo>() {}.getType());
+    assertThat(progress.totalLinesInFile).isEqualTo(5);
+    assertThat(progress.reviewers).hasSize(1);
+    ReviewerLineReviewProgressInfo a = progress.reviewers.get(0);
+    assertThat(a.percentRead).isWithin(0.001).of(0.0);
+    assertThat(a.percentTentativelyRead).isWithin(0.001).of(0.0);
+    assertThat(a.percentUnread).isWithin(0.001).of(100.0);
   }
 
   @Test

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -1978,6 +1978,60 @@ public class RevisionIT extends AbstractDaemonTest {
   }
 
   @Test
+  public void getFileLineReviewProgress_overallReadWinsOverTentativeAcrossReviewers()
+      throws Exception {
+    PushOneCommit push =
+        pushFactory.create(
+            admin.newIdent(),
+            testRepo,
+            SUBJECT,
+            FILE_NAME,
+            "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+    PushOneCommit.Result r1 = push.to("refs/for/master");
+
+    LineReviewedInput adminInput = new LineReviewedInput();
+    adminInput.line = 5;
+    adminInput.side = Side.REVISION;
+    adminRestSession.put(reviewedLinesUrl(r1.getChangeId()), adminInput).assertCreated();
+
+    // Propagation carries admin's marker forward as tentative at line 7.
+    PushOneCommit.Result r2 =
+        updateChange(r1, "new1\nnew2\nl1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+
+    LineReviewedInput userInput = new LineReviewedInput();
+    userInput.line = 7;
+    userInput.side = Side.REVISION;
+    userRestSession.put(reviewedLinesUrl(r2.getChangeId()), userInput).assertCreated();
+
+    RestResponse getResp =
+        adminRestSession.get(fileLineReviewProgressUrl(r2.getChangeId(), FILE_NAME));
+    getResp.assertOK();
+    FileLineReviewProgressInfo progress =
+        newGson()
+            .fromJson(
+                getResp.getReader(), new TypeToken<FileLineReviewProgressInfo>() {}.getType());
+
+    assertThat(progress.totalLinesInFile).isEqualTo(12);
+    assertThat(progress.reviewers).hasSize(2);
+    // Overall uses any-reviewer coverage with READ precedence over tentative on the same line.
+    assertThat(progress.percentRead).isWithin(0.001).of(100.0 / 12.0);
+    assertThat(progress.percentTentativelyRead).isWithin(0.001).of(0.0);
+    assertThat(progress.percentUnread).isWithin(0.001).of(100.0 * 11 / 12);
+
+    Double adminTentative = null;
+    Double userRead = null;
+    for (ReviewerLineReviewProgressInfo reviewer : progress.reviewers) {
+      if (reviewer.account._accountId == admin.id().get()) {
+        adminTentative = reviewer.percentTentativelyRead;
+      } else if (reviewer.account._accountId == user.id().get()) {
+        userRead = reviewer.percentRead;
+      }
+    }
+    assertThat(adminTentative).isWithin(0.001).of(100.0 / 12.0);
+    assertThat(userRead).isWithin(0.001).of(100.0 / 12.0);
+  }
+
+  @Test
   public void getFileLineReviewProgress_unreviewedFile_percentReadIsZero() throws Exception {
     String fiveLines = "l1\nl2\nl3\nl4\nl5\n";
     PushOneCommit push =

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -96,10 +96,12 @@ import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.ChangeMessageInfo;
 import com.google.gerrit.extensions.common.CommentInfo;
 import com.google.gerrit.extensions.common.CommitInfo;
+import com.google.gerrit.extensions.common.FileLineReviewProgressInfo;
 import com.google.gerrit.extensions.common.FileInfo;
 import com.google.gerrit.extensions.common.GitPerson;
 import com.google.gerrit.extensions.common.LabelInfo;
 import com.google.gerrit.extensions.common.MergeableInfo;
+import com.google.gerrit.extensions.common.ReviewerLineReviewProgressInfo;
 import com.google.gerrit.extensions.common.RevisionInfo;
 import com.google.gerrit.extensions.common.RevisionInfo.ParentInfo;
 import com.google.gerrit.extensions.common.WebLinkInfo;
@@ -1767,6 +1769,109 @@ public class RevisionIT extends AbstractDaemonTest {
 
   private String reviewedLinesUrl(String changeId) {
     return "/changes/" + changeId + "/revisions/current/files/" + FILE_NAME + "/reviewed_lines";
+  }
+
+  private String fileLineReviewProgressUrl(String changeId, String fileName) {
+    return "/changes/" + changeId + "/revisions/current/files/" + fileName + "/line_review_progress";
+  }
+
+  @Test
+  public void getFileLineReviewProgress_percentagesUseWholeFileLineCount() throws Exception {
+    PushOneCommit.Result r =
+        createChange(SUBJECT, FILE_NAME, "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 5;
+    input.side = Side.REVISION;
+    adminRestSession.put(reviewedLinesUrl(r.getChangeId()), input).assertCreated();
+
+    RestResponse getResp =
+        adminRestSession.get(fileLineReviewProgressUrl(r.getChangeId(), FILE_NAME));
+    getResp.assertOK();
+    FileLineReviewProgressInfo progress =
+        newGson()
+            .fromJson(
+                getResp.getReader(), new TypeToken<FileLineReviewProgressInfo>() {}.getType());
+    assertThat(progress.totalLinesInFile).isEqualTo(10);
+    assertThat(progress.reviewers).hasSize(1);
+    ReviewerLineReviewProgressInfo a = progress.reviewers.get(0);
+    assertThat(a.account._accountId).isEqualTo(admin.id().get());
+    assertThat(a.percentRead).isWithin(0.001).of(10.0);
+    assertThat(a.percentTentativelyRead).isWithin(0.001).of(0.0);
+    assertThat(a.percentUnread).isWithin(0.001).of(90.0);
+  }
+
+  @Test
+  public void getFileLineReviewProgress_separateDenominatorPerFile() throws Exception {
+    String fiveLines = "l1\nl2\nl3\nl4\nl5\n";
+    PushOneCommit push =
+        pushFactory.create(
+            admin.newIdent(),
+            testRepo,
+            SUBJECT,
+            ImmutableMap.of(FILE_NAME, fiveLines, "b.txt", fiveLines));
+    PushOneCommit.Result r = push.to("refs/for/master");
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 2;
+    input.side = Side.REVISION;
+    adminRestSession.put(reviewedLinesUrl(r.getChangeId()), input).assertCreated();
+
+    RestResponse fileA =
+        adminRestSession.get(fileLineReviewProgressUrl(r.getChangeId(), FILE_NAME));
+    fileA.assertOK();
+    FileLineReviewProgressInfo pa =
+        newGson()
+            .fromJson(fileA.getReader(), new TypeToken<FileLineReviewProgressInfo>() {}.getType());
+    assertThat(pa.totalLinesInFile).isEqualTo(5);
+    assertThat(pa.reviewers).hasSize(1);
+    assertThat(pa.reviewers.get(0).percentRead).isWithin(0.001).of(20.0);
+
+    RestResponse fileB =
+        adminRestSession.get(fileLineReviewProgressUrl(r.getChangeId(), "b.txt"));
+    fileB.assertOK();
+    FileLineReviewProgressInfo pb =
+        newGson()
+            .fromJson(fileB.getReader(), new TypeToken<FileLineReviewProgressInfo>() {}.getType());
+    assertThat(pb.totalLinesInFile).isEqualTo(5);
+    assertThat(pb.reviewers).hasSize(1);
+    assertThat(pb.reviewers.get(0).percentRead).isWithin(0.001).of(0.0);
+    assertThat(pb.reviewers.get(0).percentUnread).isWithin(0.001).of(100.0);
+  }
+
+  @Test
+  public void getFileLineReviewProgress_tentativelyReadPercent_nonZeroAfterPropagation()
+      throws Exception {
+    PushOneCommit push =
+        pushFactory.create(
+            admin.newIdent(),
+            testRepo,
+            SUBJECT,
+            FILE_NAME,
+            "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+    PushOneCommit.Result r1 = push.to("refs/for/master");
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 5;
+    input.side = Side.REVISION;
+    adminRestSession.put(reviewedLinesUrl(r1.getChangeId()), input).assertCreated();
+
+    // Two lines inserted at top: former line 5 is now line 7; propagation stores it as tentative.
+    PushOneCommit.Result r2 =
+        updateChange(r1, "new1\nnew2\nl1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+
+    RestResponse getResp =
+        adminRestSession.get(fileLineReviewProgressUrl(r2.getChangeId(), FILE_NAME));
+    getResp.assertOK();
+    FileLineReviewProgressInfo progress =
+        newGson()
+            .fromJson(
+                getResp.getReader(), new TypeToken<FileLineReviewProgressInfo>() {}.getType());
+    assertThat(progress.totalLinesInFile).isEqualTo(12);
+    assertThat(progress.reviewers).hasSize(1);
+    ReviewerLineReviewProgressInfo a = progress.reviewers.get(0);
+    assertThat(a.account._accountId).isEqualTo(admin.id().get());
+    assertThat(a.percentRead).isWithin(0.001).of(0.0);
+    assertThat(a.percentTentativelyRead).isWithin(0.001).of(100.0 / 12.0);
+    assertThat(a.percentUnread).isWithin(0.001).of(100.0 * 11 / 12);
   }
 
   @Test

--- a/javatests/com/google/gerrit/server/change/FileLineReviewProgressComputerTest.java
+++ b/javatests/com/google/gerrit/server/change/FileLineReviewProgressComputerTest.java
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.change;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gerrit.extensions.client.ReviewStatus;
+import org.junit.Test;
+
+public class FileLineReviewProgressComputerTest {
+  private static final String FILE = "a.txt";
+
+  @Test
+  public void compute_readOverridesTentativeAndParentSideIgnored() {
+    FileLineReviewProgressComputer.Counts counts =
+        FileLineReviewProgressComputer.compute(
+            ImmutableList.of(
+                line(1, 1, 1, ReviewStatus.TENTATIVELY_READ),
+                line(1, 1, 2, ReviewStatus.READ),
+                line(3, 3, 0, ReviewStatus.READ)),
+            5);
+
+    assertThat(counts.readLines).isEqualTo(1);
+    assertThat(counts.tentativelyReadLines).isEqualTo(0);
+    assertThat(counts.unreadLines).isEqualTo(4);
+  }
+
+  @Test
+  public void compute_mergesOverlappingRangesWithoutDoubleCounting() {
+    FileLineReviewProgressComputer.Counts counts =
+        FileLineReviewProgressComputer.compute(
+            ImmutableList.of(
+                line(2, 4, 1, ReviewStatus.READ),
+                line(3, 5, 1, ReviewStatus.READ),
+                line(6, 7, 1, ReviewStatus.TENTATIVELY_READ)),
+            10);
+
+    assertThat(counts.readLines).isEqualTo(4);
+    assertThat(counts.tentativelyReadLines).isEqualTo(2);
+    assertThat(counts.unreadLines).isEqualTo(4);
+  }
+
+  @Test
+  public void compute_clipsOutOfBoundsRangesToFileSize() {
+    FileLineReviewProgressComputer.Counts counts =
+        FileLineReviewProgressComputer.compute(
+            ImmutableList.of(
+                line(-3, 2, 1, ReviewStatus.READ),
+                line(9, 20, 1, ReviewStatus.TENTATIVELY_READ)),
+            10);
+
+    assertThat(counts.readLines).isEqualTo(2);
+    assertThat(counts.tentativelyReadLines).isEqualTo(2);
+    assertThat(counts.unreadLines).isEqualTo(6);
+  }
+
+  @Test
+  public void compute_zeroOrNegativeFileSizeReturnsAllZeroes() {
+    FileLineReviewProgressComputer.Counts zero =
+        FileLineReviewProgressComputer.compute(
+            ImmutableList.of(line(1, 1, 1, ReviewStatus.READ)), 0);
+    FileLineReviewProgressComputer.Counts negative =
+        FileLineReviewProgressComputer.compute(
+            ImmutableList.of(line(1, 1, 1, ReviewStatus.TENTATIVELY_READ)), -1);
+
+    assertThat(zero.readLines).isEqualTo(0);
+    assertThat(zero.tentativelyReadLines).isEqualTo(0);
+    assertThat(zero.unreadLines).isEqualTo(0);
+    assertThat(negative.readLines).isEqualTo(0);
+    assertThat(negative.tentativelyReadLines).isEqualTo(0);
+    assertThat(negative.unreadLines).isEqualTo(0);
+  }
+
+  private static AccountPatchLineReviewStore.ReviewedLine line(
+      int startLine, int endLine, int side, ReviewStatus status) {
+    return AccountPatchLineReviewStore.ReviewedLine.create(
+        FILE, endLine, (short) side, startLine, 0, endLine, 0, status);
+  }
+}

--- a/javatests/com/google/gerrit/server/restapi/change/GetFileLineReviewProgressTest.java
+++ b/javatests/com/google/gerrit/server/restapi/change/GetFileLineReviewProgressTest.java
@@ -1,0 +1,165 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.restapi.change;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.gerrit.entities.Account;
+import com.google.gerrit.entities.Change;
+import com.google.gerrit.entities.PatchSet;
+import com.google.gerrit.entities.Project;
+import com.google.gerrit.extensions.client.ReviewStatus;
+import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.FileLineReviewProgressInfo;
+import com.google.gerrit.extensions.common.ReviewerLineReviewProgressInfo;
+import com.google.gerrit.server.account.AccountLoader;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.PatchSetWithReviewedLines;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.ReviewedLine;
+import com.google.gerrit.server.change.FileResource;
+import com.google.gerrit.server.change.RevisionFileLineCounts;
+import com.google.gerrit.server.change.RevisionResource;
+import com.google.gerrit.server.plugincontext.PluginContext.ExtensionImplFunction;
+import com.google.gerrit.server.plugincontext.PluginItemContext;
+import com.google.gerrit.server.permissions.PermissionBackendException;
+import java.io.IOException;
+import java.time.Instant;
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GetFileLineReviewProgressTest {
+  private static final String FILE = "a.txt";
+  private static final PatchSet.Id PS1 = PatchSet.id(Change.id(1), 1);
+  private static final Account.Id ACCOUNT_1 = Account.id(1001);
+  private static final Account.Id ACCOUNT_2 = Account.id(1002);
+
+  @Mock private PluginItemContext<AccountPatchLineReviewStore> pluginItemContext;
+  @Mock private RevisionFileLineCounts revisionFileLineCounts;
+  @Mock private AccountLoader.Factory accountLoaderFactory;
+  @Mock private AccountLoader accountLoader;
+  @Mock private AccountPatchLineReviewStore store;
+  @Mock private RevisionResource revisionResource;
+
+  private GetFileLineReviewProgress getFileLineReviewProgress;
+  private FileResource fileResource;
+
+  @Before
+  public void setUp() {
+    getFileLineReviewProgress =
+        new GetFileLineReviewProgress(
+            pluginItemContext, revisionFileLineCounts, accountLoaderFactory);
+    when(accountLoaderFactory.create(true)).thenReturn(accountLoader);
+    when(accountLoader.get(ACCOUNT_1)).thenReturn(new AccountInfo(ACCOUNT_1.get()));
+    when(accountLoader.get(ACCOUNT_2)).thenReturn(new AccountInfo(ACCOUNT_2.get()));
+
+    when(pluginItemContext.call(any()))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              ExtensionImplFunction<AccountPatchLineReviewStore, ?> fn = invocation.getArgument(0);
+              return fn.call(store);
+            });
+
+    PatchSet patchSet =
+        PatchSet.builder()
+            .id(PS1)
+            .commitId(ObjectId.fromString("1111111111111111111111111111111111111111"))
+            .uploader(Account.id(1))
+            .realUploader(Account.id(1))
+            .createdOn(Instant.now())
+            .build();
+    when(revisionResource.getPatchSet()).thenReturn(patchSet);
+    when(revisionResource.getProject()).thenReturn(Project.nameKey("test"));
+    fileResource = new FileResource(revisionResource, FILE);
+  }
+
+  @Test
+  public void apply_computesPerReviewerAndOverallPercentages() throws IOException, PermissionBackendException {
+    when(revisionFileLineCounts.countLines(any(), any(), any())).thenReturn(10);
+    when(store.accountsWithLineReviews(PS1)).thenReturn(ImmutableSet.of(ACCOUNT_2, ACCOUNT_1));
+
+    when(store.findReviewedLines(PS1, ACCOUNT_1, FILE))
+        .thenReturn(
+            java.util.Optional.of(
+                PatchSetWithReviewedLines.create(
+                    PS1,
+                    ImmutableList.of(
+                        line(2, 2, ReviewStatus.READ),
+                        line(3, 3, ReviewStatus.TENTATIVELY_READ)))));
+    when(store.findReviewedLines(PS1, ACCOUNT_2, FILE))
+        .thenReturn(
+            java.util.Optional.of(
+                PatchSetWithReviewedLines.create(
+                    PS1, ImmutableList.of(line(3, 3, ReviewStatus.READ)))));
+
+    FileLineReviewProgressInfo out = getFileLineReviewProgress.apply(fileResource).value();
+
+    assertThat(out.totalLinesInFile).isEqualTo(10);
+    assertThat(out.reviewers).hasSize(2);
+    // Sorted by account ID.
+    ReviewerLineReviewProgressInfo first = out.reviewers.get(0);
+    ReviewerLineReviewProgressInfo second = out.reviewers.get(1);
+    assertThat(first.account._accountId).isEqualTo(ACCOUNT_1.get());
+    assertThat(first.percentRead).isWithin(0.001).of(10.0);
+    assertThat(first.percentTentativelyRead).isWithin(0.001).of(10.0);
+    assertThat(first.percentUnread).isWithin(0.001).of(80.0);
+
+    assertThat(second.account._accountId).isEqualTo(ACCOUNT_2.get());
+    assertThat(second.percentRead).isWithin(0.001).of(10.0);
+    assertThat(second.percentTentativelyRead).isWithin(0.001).of(0.0);
+    assertThat(second.percentUnread).isWithin(0.001).of(90.0);
+
+    // Overall uses any-reviewer coverage and READ precedence on overlapping line 3.
+    assertThat(out.percentRead).isWithin(0.001).of(20.0);
+    assertThat(out.percentTentativelyRead).isWithin(0.001).of(0.0);
+    assertThat(out.percentUnread).isWithin(0.001).of(80.0);
+  }
+
+  @Test
+  public void apply_withZeroTotalLines_setsNullPercentages() throws IOException, PermissionBackendException {
+    when(revisionFileLineCounts.countLines(any(), any(), any())).thenReturn(0);
+    when(store.accountsWithLineReviews(PS1)).thenReturn(ImmutableSet.of(ACCOUNT_1));
+    when(store.findReviewedLines(PS1, ACCOUNT_1, FILE))
+        .thenReturn(
+            java.util.Optional.of(
+                PatchSetWithReviewedLines.create(
+                    PS1, ImmutableList.of(line(1, 1, ReviewStatus.READ)))));
+
+    FileLineReviewProgressInfo out = getFileLineReviewProgress.apply(fileResource).value();
+
+    assertThat(out.totalLinesInFile).isEqualTo(0);
+    assertThat(out.percentRead).isNull();
+    assertThat(out.percentTentativelyRead).isNull();
+    assertThat(out.percentUnread).isNull();
+    assertThat(out.reviewers).hasSize(1);
+    assertThat(out.reviewers.get(0).percentRead).isNull();
+    assertThat(out.reviewers.get(0).percentTentativelyRead).isNull();
+    assertThat(out.reviewers.get(0).percentUnread).isNull();
+  }
+
+  private static ReviewedLine line(int startLine, int endLine, ReviewStatus status) {
+    return ReviewedLine.create(FILE, endLine, (short) 1, startLine, 0, endLine, 0, status);
+  }
+}


### PR DESCRIPTION
- for each reviewer for a given file, able to fetch percent of lines read, tentatively read, and unread
- add functionality to calculate number of lines in file
- add tests in RevisionIT