### PR TITLE
Implement backend support for read marker logs

### DIFF
--- a/java/com/google/gerrit/extensions/common/LineReviewHistoryInfo.java
+++ b/java/com/google/gerrit/extensions/common/LineReviewHistoryInfo.java
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import com.google.gerrit.extensions.client.Comment.Range;
+import com.google.gerrit.extensions.client.Side;
+import java.sql.Timestamp;
+
+/** Represents a single entry in the line review history for a change. */
+public class LineReviewHistoryInfo {
+  public String file;
+  public Integer line;
+  public Side side;
+  public Range range;
+  public String action;
+  public Timestamp timestamp;
+}

--- a/java/com/google/gerrit/extensions/common/LineReviewHistoryInfo.java
+++ b/java/com/google/gerrit/extensions/common/LineReviewHistoryInfo.java
@@ -18,8 +18,9 @@ import com.google.gerrit.extensions.client.Comment.Range;
 import com.google.gerrit.extensions.client.Side;
 import java.sql.Timestamp;
 
-/** Represents a single entry in the line review history for a change. */
+/** Represents a single entry in the unified line review history for a change. */
 public class LineReviewHistoryInfo {
+  public Integer accountId;
   public String file;
   public Integer line;
   public Side side;

--- a/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
@@ -245,15 +245,13 @@ public interface AccountPatchLineReviewStore {
   }
 
   /**
-   * Returns the full history of mark/unmark actions for the given user on the given change,
+   * Returns the full unified history of mark/unmark actions for the given change across all users,
    * ordered chronologically (oldest first).
    *
    * @param changeId change ID
-   * @param accountId account ID of the user
    * @return list of history entries
    */
-  default ImmutableList<LineReviewHistoryEntry> findLineReviewHistory(
-      Change.Id changeId, Account.Id accountId) {
+  default ImmutableList<LineReviewHistoryEntry> findLineReviewHistory(Change.Id changeId) {
     throw new NotImplementedException(
         "findLineReviewHistory() is not implemented for this AccountPatchLineReviewStore.");
   }

--- a/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/change/AccountPatchLineReviewStore.java
@@ -16,6 +16,7 @@ package com.google.gerrit.server.change;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
@@ -23,6 +24,7 @@ import com.google.gerrit.extensions.api.changes.LineReviewedInput;
 import com.google.gerrit.extensions.client.Comment.Range;
 import com.google.gerrit.extensions.client.Side;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
+import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -37,6 +39,60 @@ import java.util.Optional;
  * primary servers.
  */
 public interface AccountPatchLineReviewStore {
+
+  /** Whether a line was marked or unmarked in a history entry. */
+  enum LineReviewAction {
+    MARKED,
+    UNMARKED
+  }
+
+  /** A single entry in the line review history for a user. */
+  @AutoValue
+  abstract class LineReviewHistoryEntry {
+    public abstract PatchSet.Id patchSetId();
+
+    public abstract Account.Id accountId();
+
+    public abstract String path();
+
+    public abstract int lineNumber();
+
+    public abstract short side();
+
+    public abstract int startLine();
+
+    public abstract int startChar();
+
+    public abstract int endLine();
+
+    public abstract int endChar();
+
+    public abstract LineReviewAction action();
+
+    public abstract Timestamp createdOn();
+
+    public static LineReviewHistoryEntry create(
+        PatchSet.Id patchSetId,
+        Account.Id accountId,
+        String path,
+        int lineNumber,
+        short side,
+        int startLine,
+        int startChar,
+        int endLine,
+        int endChar,
+        LineReviewAction action,
+        Timestamp createdOn) {
+      return new AutoValue_AccountPatchLineReviewStore_LineReviewHistoryEntry(
+          patchSetId, accountId, path, lineNumber, side, startLine, startChar, endLine, endChar,
+          action, createdOn);
+    }
+
+    public Side getSide() {
+      Side s = Side.fromShort(side());
+      return s != null ? s : Side.REVISION;
+    }
+  }
 
   /** Describes a single reviewed line or region within a file. */
   @AutoValue
@@ -160,4 +216,45 @@ public interface AccountPatchLineReviewStore {
    */
   Optional<PatchSetWithReviewedLines> findReviewedLines(
       PatchSet.Id psId, Account.Id accountId, String path);
+
+  /**
+   * Finds all reviewed lines/regions for the given patch set and file across all users.
+   *
+   * @param psId patch set ID
+   * @param path file path to filter by (required)
+   * @return map of account ID to list of reviewed lines/regions for that account
+   */
+  default ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> findAllReviewedLines(
+      PatchSet.Id psId, String path) {
+    throw new NotImplementedException(
+        "findAllReviewedLines() is not implemented for this AccountPatchLineReviewStore.");
+  }
+
+  /**
+   * Logs a mark or unmark action for the given user to the history table. Called after a successful
+   * {@link #markLineReviewed} or {@link #clearLineReviewed}. History is best-effort.
+   */
+  default void logLineReviewAction(
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      LineReviewedInput input,
+      LineReviewAction action) {
+    throw new NotImplementedException(
+        "logLineReviewAction() is not implemented for this AccountPatchLineReviewStore.");
+  }
+
+  /**
+   * Returns the full history of mark/unmark actions for the given user on the given change,
+   * ordered chronologically (oldest first).
+   *
+   * @param changeId change ID
+   * @param accountId account ID of the user
+   * @return list of history entries
+   */
+  default ImmutableList<LineReviewHistoryEntry> findLineReviewHistory(
+      Change.Id changeId, Account.Id accountId) {
+    throw new NotImplementedException(
+        "findLineReviewHistory() is not implemented for this AccountPatchLineReviewStore.");
+  }
 }

--- a/java/com/google/gerrit/server/restapi/change/ChangeRestApiModule.java
+++ b/java/com/google/gerrit/server/restapi/change/ChangeRestApiModule.java
@@ -187,6 +187,7 @@ public class ChangeRestApiModule extends RestApiModule {
     post(REVISION_KIND, "test.submit_rule").to(TestSubmitRule.class);
     post(REVISION_KIND, "test.submit_type").to(TestSubmitType.class);
 
+    get(CHANGE_KIND, "reviewed_line_history").to(GetLineReviewHistory.class);
     get(CHANGE_KIND, "robotcomments").to(ListChangeRobotComments.class);
     delete(CHANGE_KIND, "topic").to(PutTopic.class);
     get(CHANGE_KIND, "topic").to(GetTopic.class);

--- a/java/com/google/gerrit/server/restapi/change/GetLineReviewHistory.java
+++ b/java/com/google/gerrit/server/restapi/change/GetLineReviewHistory.java
@@ -15,7 +15,6 @@
 package com.google.gerrit.server.restapi.change;
 
 import com.google.common.collect.ImmutableList;
-import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.extensions.client.Comment.Range;
 import com.google.gerrit.extensions.common.LineReviewHistoryInfo;
@@ -46,15 +45,15 @@ public class GetLineReviewHistory implements RestReadView<ChangeResource> {
     if (!rsrc.getUser().isIdentifiedUser()) {
       throw new AuthException("Authentication required");
     }
-    Account.Id accountId = rsrc.getUser().asIdentifiedUser().getAccountId();
     Change.Id changeId = rsrc.getChange().getId();
 
     ImmutableList<LineReviewHistoryEntry> entries =
-        accountPatchLineReviewStore.call(s -> s.findLineReviewHistory(changeId, accountId));
+        accountPatchLineReviewStore.call(s -> s.findLineReviewHistory(changeId));
 
     List<LineReviewHistoryInfo> result = new ArrayList<>();
     for (LineReviewHistoryEntry entry : entries) {
       LineReviewHistoryInfo info = new LineReviewHistoryInfo();
+      info.accountId = entry.accountId().get();
       info.file = entry.path();
       info.line = entry.lineNumber();
       info.side = entry.getSide();

--- a/java/com/google/gerrit/server/restapi/change/GetLineReviewHistory.java
+++ b/java/com/google/gerrit/server/restapi/change/GetLineReviewHistory.java
@@ -1,0 +1,76 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.server.restapi.change;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gerrit.entities.Account;
+import com.google.gerrit.entities.Change;
+import com.google.gerrit.extensions.client.Comment.Range;
+import com.google.gerrit.extensions.common.LineReviewHistoryInfo;
+import com.google.gerrit.extensions.restapi.AuthException;
+import com.google.gerrit.extensions.restapi.Response;
+import com.google.gerrit.extensions.restapi.RestReadView;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.LineReviewHistoryEntry;
+import com.google.gerrit.server.change.ChangeResource;
+import com.google.gerrit.server.plugincontext.PluginItemContext;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class GetLineReviewHistory implements RestReadView<ChangeResource> {
+  private final PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore;
+
+  @Inject
+  GetLineReviewHistory(
+      PluginItemContext<AccountPatchLineReviewStore> accountPatchLineReviewStore) {
+    this.accountPatchLineReviewStore = accountPatchLineReviewStore;
+  }
+
+  @Override
+  public Response<List<LineReviewHistoryInfo>> apply(ChangeResource rsrc) throws AuthException {
+    if (!rsrc.getUser().isIdentifiedUser()) {
+      throw new AuthException("Authentication required");
+    }
+    Account.Id accountId = rsrc.getUser().asIdentifiedUser().getAccountId();
+    Change.Id changeId = rsrc.getChange().getId();
+
+    ImmutableList<LineReviewHistoryEntry> entries =
+        accountPatchLineReviewStore.call(s -> s.findLineReviewHistory(changeId, accountId));
+
+    List<LineReviewHistoryInfo> result = new ArrayList<>();
+    for (LineReviewHistoryEntry entry : entries) {
+      LineReviewHistoryInfo info = new LineReviewHistoryInfo();
+      info.file = entry.path();
+      info.line = entry.lineNumber();
+      info.side = entry.getSide();
+      if (entry.startLine() != entry.endLine()
+          || entry.startChar() != 0
+          || entry.endChar() != 0) {
+        info.range = new Range();
+        info.range.startLine = entry.startLine();
+        info.range.startCharacter = entry.startChar();
+        info.range.endLine = entry.endLine();
+        info.range.endCharacter = entry.endChar();
+      }
+      info.action = entry.action().name();
+      info.timestamp = entry.createdOn();
+      result.add(info);
+    }
+    return Response.ok(result);
+  }
+}

--- a/java/com/google/gerrit/server/schema/CloudSpannerAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/CloudSpannerAccountPatchLineReviewStore.java
@@ -14,15 +14,22 @@
 
 package com.google.gerrit.server.schema;
 
+import com.google.gerrit.entities.Account;
+import com.google.gerrit.entities.PatchSet;
 import com.google.gerrit.exceptions.DuplicateKeyException;
 import com.google.gerrit.exceptions.StorageException;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.LineReviewAction;
 import com.google.gerrit.server.config.GerritServerConfig;
 import com.google.gerrit.server.config.SitePaths;
 import com.google.gerrit.server.config.ThreadSettingsConfig;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.UUID;
 import org.eclipse.jgit.lib.Config;
 
 @Singleton
@@ -62,5 +69,63 @@ public class CloudSpannerAccountPatchLineReviewStore extends JdbcAccountPatchLin
             + "end_char INT64 NOT NULL DEFAULT (0)"
             + ") PRIMARY KEY(change_id, patch_set_id, account_id, file_name, line_number, side, "
             + "start_line, start_char, end_line, end_char)");
+  }
+
+  @Override
+  protected void insertHistoryEntry(
+      Connection con,
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      int lineNumber,
+      short side,
+      int startLine,
+      int startChar,
+      int endLine,
+      int endChar,
+      LineReviewAction action)
+      throws SQLException {
+    try (PreparedStatement stmt =
+        con.prepareStatement(
+            "INSERT INTO account_patch_line_review_history "
+                + "(id, account_id, change_id, patch_set_id, file_name, line_number, side, "
+                + "start_line, start_char, end_line, end_char, action, created_on) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+      stmt.setString(1, UUID.randomUUID().toString());
+      stmt.setInt(2, accountId.get());
+      stmt.setInt(3, psId.changeId().get());
+      stmt.setInt(4, psId.get());
+      stmt.setString(5, path);
+      stmt.setInt(6, lineNumber);
+      stmt.setShort(7, side);
+      stmt.setInt(8, startLine);
+      stmt.setInt(9, startChar);
+      stmt.setInt(10, endLine);
+      stmt.setInt(11, endChar);
+      stmt.setString(12, action.name());
+      stmt.setTimestamp(13, new Timestamp(System.currentTimeMillis()));
+      stmt.executeUpdate();
+    }
+  }
+
+  @Override
+  protected void doCreateHistoryTable(Statement stmt) throws SQLException {
+    // Spanner does not support auto-increment; use a UUID string as the primary key.
+    stmt.executeUpdate(
+        "CREATE TABLE IF NOT EXISTS account_patch_line_review_history ("
+            + "id STRING(36) NOT NULL,"
+            + "account_id INT64 NOT NULL DEFAULT (0),"
+            + "change_id INT64 NOT NULL DEFAULT (0),"
+            + "patch_set_id INT64 NOT NULL DEFAULT (0),"
+            + "file_name STRING(MAX) NOT NULL DEFAULT (''),"
+            + "line_number INT64 NOT NULL DEFAULT (1),"
+            + "side INT64 NOT NULL DEFAULT (1),"
+            + "start_line INT64 NOT NULL DEFAULT (1),"
+            + "start_char INT64 NOT NULL DEFAULT (0),"
+            + "end_line INT64 NOT NULL DEFAULT (1),"
+            + "end_char INT64 NOT NULL DEFAULT (0),"
+            + "action STRING(10) NOT NULL DEFAULT ('MARKED'),"
+            + "created_on TIMESTAMP NOT NULL"
+            + ") PRIMARY KEY(id)");
   }
 }

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -581,29 +581,25 @@ public abstract class JdbcAccountPatchLineReviewStore
   }
 
   @Override
-  public ImmutableList<LineReviewHistoryEntry> findLineReviewHistory(
-      Change.Id changeId, Account.Id accountId) {
+  public ImmutableList<LineReviewHistoryEntry> findLineReviewHistory(Change.Id changeId) {
     try (TraceTimer ignored =
             TraceContext.newTimer(
                 "Find line review history",
-                Metadata.builder()
-                    .changeId(changeId.get())
-                    .accountId(accountId.get())
-                    .build());
+                Metadata.builder().changeId(changeId.get()).build());
         Connection con = ds.getConnection();
         PreparedStatement stmt =
             con.prepareStatement(
-                "SELECT patch_set_id, file_name, line_number, side, start_line, start_char, "
-                    + "end_line, end_char, action, created_on "
+                "SELECT account_id, patch_set_id, file_name, line_number, side, start_line, "
+                    + "start_char, end_line, end_char, action, created_on "
                     + "FROM account_patch_line_review_history "
-                    + "WHERE change_id = ? AND account_id = ? "
+                    + "WHERE change_id = ? "
                     + "ORDER BY created_on ASC")) {
       stmt.setInt(1, changeId.get());
-      stmt.setInt(2, accountId.get());
       try (ResultSet rs = stmt.executeQuery()) {
         ImmutableList.Builder<LineReviewHistoryEntry> builder = ImmutableList.builder();
         while (rs.next()) {
           PatchSet.Id psId = PatchSet.id(changeId, rs.getInt("patch_set_id"));
+          Account.Id accountId = Account.id(rs.getInt("account_id"));
           builder.add(
               LineReviewHistoryEntry.create(
                   psId,

--- a/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStore.java
@@ -18,6 +18,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.FluentLogger;
 import com.google.common.primitives.Ints;
 import com.google.gerrit.entities.Account;
@@ -44,7 +45,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import javax.sql.DataSource;
@@ -225,6 +229,14 @@ public abstract class JdbcAccountPatchLineReviewStore
           .withCause(e)
           .log("Failed to create table to store account patch line reviews");
     }
+    try {
+      createHistoryTableIfNotExists();
+    } catch (StorageException e) {
+      logger
+          .atSevere()
+          .withCause(e)
+          .log("Failed to create table to store account patch line review history");
+    }
   }
 
   public Connection getConnection() throws SQLException {
@@ -238,6 +250,34 @@ public abstract class JdbcAccountPatchLineReviewStore
     } catch (SQLException e) {
       throw convertError("create", e);
     }
+  }
+
+  public void createHistoryTableIfNotExists() {
+    try (Connection con = ds.getConnection();
+        Statement stmt = con.createStatement()) {
+      doCreateHistoryTable(stmt);
+    } catch (SQLException e) {
+      throw convertError("create", e);
+    }
+  }
+
+  protected void doCreateHistoryTable(Statement stmt) throws SQLException {
+    stmt.executeUpdate(
+        "CREATE TABLE IF NOT EXISTS account_patch_line_review_history ("
+            + "id BIGINT GENERATED ALWAYS AS IDENTITY, "
+            + "account_id INTEGER DEFAULT 0 NOT NULL, "
+            + "change_id INTEGER DEFAULT 0 NOT NULL, "
+            + "patch_set_id INTEGER DEFAULT 0 NOT NULL, "
+            + "file_name VARCHAR(4096) DEFAULT '' NOT NULL, "
+            + "line_number INTEGER DEFAULT 1 NOT NULL, "
+            + "side SMALLINT DEFAULT 1 NOT NULL, "
+            + "start_line INTEGER DEFAULT 1 NOT NULL, "
+            + "start_char INTEGER DEFAULT 0 NOT NULL, "
+            + "end_line INTEGER DEFAULT 1 NOT NULL, "
+            + "end_char INTEGER DEFAULT 0 NOT NULL, "
+            + "action VARCHAR(10) DEFAULT 'MARKED' NOT NULL, "
+            + "created_on TIMESTAMP NOT NULL"
+            + ")");
   }
 
   protected void doCreateTable(Statement stmt) throws SQLException {
@@ -278,31 +318,43 @@ public abstract class JdbcAccountPatchLineReviewStore
                     .accountId(accountId.get())
                     .filePath(path)
                     .build());
-        Connection con = ds.getConnection();
-        PreparedStatement stmt =
-            con.prepareStatement(
-                "INSERT INTO account_patch_line_reviews "
-                    + "(account_id, change_id, patch_set_id, file_name, line_number, side, "
-                    + "start_line, start_char, end_line, end_char) VALUES "
-                    + "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
-      stmt.setInt(1, accountId.get());
-      stmt.setInt(2, psId.changeId().get());
-      stmt.setInt(3, psId.get());
-      stmt.setString(4, path);
-      stmt.setInt(5, lineNumber[0]);
-      stmt.setShort(6, sideToShort(side));
-      stmt.setInt(7, startLine[0]);
-      stmt.setInt(8, startChar[0]);
-      stmt.setInt(9, endLine[0]);
-      stmt.setInt(10, endChar[0]);
-      stmt.executeUpdate();
+        Connection con = ds.getConnection()) {
+      try (PreparedStatement stmt =
+          con.prepareStatement(
+              "INSERT INTO account_patch_line_reviews "
+                  + "(account_id, change_id, patch_set_id, file_name, line_number, side, "
+                  + "start_line, start_char, end_line, end_char) VALUES "
+                  + "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+        stmt.setInt(1, accountId.get());
+        stmt.setInt(2, psId.changeId().get());
+        stmt.setInt(3, psId.get());
+        stmt.setString(4, path);
+        stmt.setInt(5, lineNumber[0]);
+        stmt.setShort(6, sideToShort(side));
+        stmt.setInt(7, startLine[0]);
+        stmt.setInt(8, startChar[0]);
+        stmt.setInt(9, endLine[0]);
+        stmt.setInt(10, endChar[0]);
+        stmt.executeUpdate();
+      } catch (SQLException e) {
+        StorageException ormException = convertError("insert", e);
+        if (ormException instanceof DuplicateKeyException) {
+          return false; // already marked — do not log
+        }
+        throw ormException;
+      }
+      // Log the mark action (best-effort: don't fail the main operation on history write failure)
+      try {
+        insertHistoryEntry(
+            con, psId, accountId, path, lineNumber[0],
+            sideToShort(side), startLine[0], startChar[0], endLine[0], endChar[0],
+            LineReviewAction.MARKED);
+      } catch (SQLException e) {
+        logger.atWarning().withCause(e).log("Failed to log MARKED action to history");
+      }
       return true;
     } catch (SQLException e) {
-      StorageException ormException = convertError("insert", e);
-      if (ormException instanceof DuplicateKeyException) {
-        return false;
-      }
-      throw ormException;
+      throw convertError("insert", e);
     }
   }
 
@@ -336,23 +388,36 @@ public abstract class JdbcAccountPatchLineReviewStore
                     .accountId(accountId.get())
                     .filePath(path)
                     .build());
-        Connection con = ds.getConnection();
-        PreparedStatement stmt =
-            con.prepareStatement(
-                "DELETE FROM account_patch_line_reviews WHERE account_id = ? AND change_id = ? "
-                    + "AND patch_set_id = ? AND file_name = ? AND line_number = ? AND side = ? "
-                    + "AND start_line = ? AND start_char = ? AND end_line = ? AND end_char = ?")) {
-      stmt.setInt(1, accountId.get());
-      stmt.setInt(2, psId.changeId().get());
-      stmt.setInt(3, psId.get());
-      stmt.setString(4, path);
-      stmt.setInt(5, lineNumber[0]);
-      stmt.setShort(6, sideToShort(side));
-      stmt.setInt(7, startLine[0]);
-      stmt.setInt(8, startChar[0]);
-      stmt.setInt(9, endLine[0]);
-      stmt.setInt(10, endChar[0]);
-      stmt.executeUpdate();
+        Connection con = ds.getConnection()) {
+      int affected;
+      try (PreparedStatement stmt =
+          con.prepareStatement(
+              "DELETE FROM account_patch_line_reviews WHERE account_id = ? AND change_id = ? "
+                  + "AND patch_set_id = ? AND file_name = ? AND line_number = ? AND side = ? "
+                  + "AND start_line = ? AND start_char = ? AND end_line = ? AND end_char = ?")) {
+        stmt.setInt(1, accountId.get());
+        stmt.setInt(2, psId.changeId().get());
+        stmt.setInt(3, psId.get());
+        stmt.setString(4, path);
+        stmt.setInt(5, lineNumber[0]);
+        stmt.setShort(6, sideToShort(side));
+        stmt.setInt(7, startLine[0]);
+        stmt.setInt(8, startChar[0]);
+        stmt.setInt(9, endLine[0]);
+        stmt.setInt(10, endChar[0]);
+        affected = stmt.executeUpdate();
+      }
+      // Only log if a row was actually deleted (don't log no-ops)
+      if (affected > 0) {
+        try {
+          insertHistoryEntry(
+              con, psId, accountId, path, lineNumber[0],
+              sideToShort(side), startLine[0], startChar[0], endLine[0], endChar[0],
+              LineReviewAction.UNMARKED);
+        } catch (SQLException e) {
+          logger.atWarning().withCause(e).log("Failed to log UNMARKED action to history");
+        }
+      }
     } catch (SQLException e) {
       throw convertError("delete", e);
     }
@@ -453,6 +518,151 @@ public abstract class JdbcAccountPatchLineReviewStore
           }
           return Optional.of(PatchSetWithReviewedLines.create(psId, lines));
         }
+      }
+    } catch (SQLException e) {
+      throw convertError("select", e);
+    }
+  }
+
+  /** Inserts a single row into the history table on the given already-open connection. */
+  protected void insertHistoryEntry(
+      Connection con,
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      int lineNumber,
+      short side,
+      int startLine,
+      int startChar,
+      int endLine,
+      int endChar,
+      LineReviewAction action)
+      throws SQLException {
+    try (PreparedStatement stmt =
+        con.prepareStatement(
+            "INSERT INTO account_patch_line_review_history "
+                + "(account_id, change_id, patch_set_id, file_name, line_number, side, "
+                + "start_line, start_char, end_line, end_char, action, created_on) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+      stmt.setInt(1, accountId.get());
+      stmt.setInt(2, psId.changeId().get());
+      stmt.setInt(3, psId.get());
+      stmt.setString(4, path);
+      stmt.setInt(5, lineNumber);
+      stmt.setShort(6, side);
+      stmt.setInt(7, startLine);
+      stmt.setInt(8, startChar);
+      stmt.setInt(9, endLine);
+      stmt.setInt(10, endChar);
+      stmt.setString(11, action.name());
+      stmt.setTimestamp(12, new Timestamp(System.currentTimeMillis()));
+      stmt.executeUpdate();
+    }
+  }
+
+  @Override
+  public void logLineReviewAction(
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      LineReviewedInput input,
+      LineReviewAction action) {
+    Side side = input.side != null ? input.side : Side.REVISION;
+    int[] lineNumber = new int[1];
+    int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
+    normalizeInput(input, lineNumber, startLine, startChar, endLine, endChar);
+    try (Connection con = ds.getConnection()) {
+      insertHistoryEntry(
+          con, psId, accountId, path, lineNumber[0],
+          sideToShort(side), startLine[0], startChar[0], endLine[0], endChar[0], action);
+    } catch (SQLException e) {
+      throw convertError("insert", e);
+    }
+  }
+
+  @Override
+  public ImmutableList<LineReviewHistoryEntry> findLineReviewHistory(
+      Change.Id changeId, Account.Id accountId) {
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "Find line review history",
+                Metadata.builder()
+                    .changeId(changeId.get())
+                    .accountId(accountId.get())
+                    .build());
+        Connection con = ds.getConnection();
+        PreparedStatement stmt =
+            con.prepareStatement(
+                "SELECT patch_set_id, file_name, line_number, side, start_line, start_char, "
+                    + "end_line, end_char, action, created_on "
+                    + "FROM account_patch_line_review_history "
+                    + "WHERE change_id = ? AND account_id = ? "
+                    + "ORDER BY created_on ASC")) {
+      stmt.setInt(1, changeId.get());
+      stmt.setInt(2, accountId.get());
+      try (ResultSet rs = stmt.executeQuery()) {
+        ImmutableList.Builder<LineReviewHistoryEntry> builder = ImmutableList.builder();
+        while (rs.next()) {
+          PatchSet.Id psId = PatchSet.id(changeId, rs.getInt("patch_set_id"));
+          builder.add(
+              LineReviewHistoryEntry.create(
+                  psId,
+                  accountId,
+                  rs.getString("file_name"),
+                  rs.getInt("line_number"),
+                  rs.getShort("side"),
+                  rs.getInt("start_line"),
+                  rs.getInt("start_char"),
+                  rs.getInt("end_line"),
+                  rs.getInt("end_char"),
+                  LineReviewAction.valueOf(rs.getString("action")),
+                  rs.getTimestamp("created_on")));
+        }
+        return builder.build();
+      }
+    } catch (SQLException e) {
+      throw convertError("select", e);
+    }
+  }
+
+  @Override
+  public ImmutableMap<Account.Id, ImmutableList<ReviewedLine>> findAllReviewedLines(
+      PatchSet.Id psId, String path) {
+    try (TraceTimer ignored =
+            TraceContext.newTimer(
+                "Find all reviewers' line reviewed flags",
+                Metadata.builder().patchSetId(psId.get()).filePath(path).build());
+        Connection con = ds.getConnection();
+        PreparedStatement stmt =
+            con.prepareStatement(
+                "SELECT account_id, file_name, line_number, side, start_line, start_char, "
+                    + "end_line, end_char "
+                    + "FROM account_patch_line_reviews "
+                    + "WHERE change_id = ? AND patch_set_id = ? AND file_name = ? "
+                    + "ORDER BY account_id, line_number")) {
+      stmt.setInt(1, psId.changeId().get());
+      stmt.setInt(2, psId.get());
+      stmt.setString(3, path);
+      try (ResultSet rs = stmt.executeQuery()) {
+        Map<Account.Id, ImmutableList.Builder<ReviewedLine>> builders = new LinkedHashMap<>();
+        while (rs.next()) {
+          Account.Id acctId = Account.id(rs.getInt("account_id"));
+          builders
+              .computeIfAbsent(acctId, k -> ImmutableList.builder())
+              .add(
+                  ReviewedLine.create(
+                      rs.getString("file_name"),
+                      rs.getInt("line_number"),
+                      rs.getShort("side"),
+                      rs.getInt("start_line"),
+                      rs.getInt("start_char"),
+                      rs.getInt("end_line"),
+                      rs.getInt("end_char")));
+        }
+        ImmutableMap.Builder<Account.Id, ImmutableList<ReviewedLine>> result =
+            ImmutableMap.builder();
+        builders.forEach((acctId, b) -> result.put(acctId, b.build()));
+        return result.build();
       }
     } catch (SQLException e) {
       throw convertError("select", e);

--- a/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
@@ -16,6 +16,7 @@ package com.google.gerrit.testing;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.Change;
 import com.google.gerrit.entities.PatchSet;
@@ -25,11 +26,16 @@ import com.google.gerrit.extensions.events.LifecycleListener;
 import com.google.gerrit.extensions.registration.DynamicItem;
 import com.google.gerrit.lifecycle.LifecycleModule;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.LineReviewAction;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.LineReviewHistoryEntry;
 import com.google.inject.Singleton;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -41,6 +47,7 @@ public class FakeAccountPatchLineReviewStore
     implements AccountPatchLineReviewStore, LifecycleListener {
 
   private final Set<LineEntity> store = new HashSet<>();
+  private final List<LineReviewHistoryEntry> history = new ArrayList<>();
 
   @Override
   public void start() {}
@@ -126,20 +133,31 @@ public class FakeAccountPatchLineReviewStore
     int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
     normalize(input, lineNumber, startLine, startChar, endLine, endChar);
 
+    LineEntity entity =
+        LineEntity.create(
+            psId,
+            accountId,
+            path,
+            lineNumber[0],
+            sideShort,
+            startLine[0],
+            startChar[0],
+            endLine[0],
+            endChar[0]);
+    boolean added;
     synchronized (store) {
-      LineEntity entity =
-          LineEntity.create(
-              psId,
-              accountId,
-              path,
-              lineNumber[0],
-              sideShort,
-              startLine[0],
-              startChar[0],
-              endLine[0],
-              endChar[0]);
-      return store.add(entity);
+      added = store.add(entity);
     }
+    if (added) {
+      synchronized (history) {
+        history.add(
+            LineReviewHistoryEntry.create(
+                psId, accountId, path, lineNumber[0], sideShort,
+                startLine[0], startChar[0], endLine[0], endChar[0],
+                LineReviewAction.MARKED, new Timestamp(System.currentTimeMillis())));
+      }
+    }
+    return added;
   }
 
   @Override
@@ -163,18 +181,22 @@ public class FakeAccountPatchLineReviewStore
     int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
     normalize(input, lineNumber, startLine, startChar, endLine, endChar);
 
+    LineEntity entity =
+        LineEntity.create(
+            psId, accountId, path, lineNumber[0], sideShort,
+            startLine[0], startChar[0], endLine[0], endChar[0]);
+    boolean removed;
     synchronized (store) {
-      store.remove(
-          LineEntity.create(
-              psId,
-              accountId,
-              path,
-              lineNumber[0],
-              sideShort,
-              startLine[0],
-              startChar[0],
-              endLine[0],
-              endChar[0]));
+      removed = store.remove(entity);
+    }
+    if (removed) {
+      synchronized (history) {
+        history.add(
+            LineReviewHistoryEntry.create(
+                psId, accountId, path, lineNumber[0], sideShort,
+                startLine[0], startChar[0], endLine[0], endChar[0],
+                LineReviewAction.UNMARKED, new Timestamp(System.currentTimeMillis())));
+      }
     }
   }
 
@@ -244,6 +266,42 @@ public class FakeAccountPatchLineReviewStore
         return Optional.empty();
       }
       return Optional.of(PatchSetWithReviewedLines.create(psId, lines));
+    }
+  }
+
+  @Override
+  public void logLineReviewAction(
+      PatchSet.Id psId,
+      Account.Id accountId,
+      String path,
+      LineReviewedInput input,
+      LineReviewAction action) {
+    Side side = input.side != null ? input.side : Side.REVISION;
+    short sideShort = side == Side.PARENT ? (short) 0 : (short) 1;
+    int[] lineNumber = new int[1];
+    int[] startLine = new int[1], startChar = new int[1], endLine = new int[1], endChar = new int[1];
+    normalize(input, lineNumber, startLine, startChar, endLine, endChar);
+    synchronized (history) {
+      history.add(
+          LineReviewHistoryEntry.create(
+              psId, accountId, path, lineNumber[0], sideShort,
+              startLine[0], startChar[0], endLine[0], endChar[0],
+              action, new Timestamp(System.currentTimeMillis())));
+    }
+  }
+
+  @Override
+  public ImmutableList<LineReviewHistoryEntry> findLineReviewHistory(
+      Change.Id changeId, Account.Id accountId) {
+    synchronized (history) {
+      ImmutableList.Builder<LineReviewHistoryEntry> builder = ImmutableList.builder();
+      for (LineReviewHistoryEntry entry : history) {
+        if (entry.patchSetId().changeId().equals(changeId)
+            && entry.accountId().equals(accountId)) {
+          builder.add(entry);
+        }
+      }
+      return builder.build();
     }
   }
 }

--- a/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
+++ b/java/com/google/gerrit/testing/FakeAccountPatchLineReviewStore.java
@@ -291,13 +291,11 @@ public class FakeAccountPatchLineReviewStore
   }
 
   @Override
-  public ImmutableList<LineReviewHistoryEntry> findLineReviewHistory(
-      Change.Id changeId, Account.Id accountId) {
+  public ImmutableList<LineReviewHistoryEntry> findLineReviewHistory(Change.Id changeId) {
     synchronized (history) {
       ImmutableList.Builder<LineReviewHistoryEntry> builder = ImmutableList.builder();
       for (LineReviewHistoryEntry entry : history) {
-        if (entry.patchSetId().changeId().equals(changeId)
-            && entry.accountId().equals(accountId)) {
+        if (entry.patchSetId().changeId().equals(changeId)) {
           builder.add(entry);
         }
       }

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -3078,7 +3078,7 @@ public class RevisionIT extends AbstractDaemonTest {
   }
 
   @Test
-  public void getReviewedLineHistory_isolatedByUser() throws Exception {
+  public void getReviewedLineHistory_unifiedAcrossUsers() throws Exception {
     PushOneCommit.Result r = createChange();
     String linesUrl = reviewedLinesUrl(r.getChangeId());
 
@@ -3088,12 +3088,15 @@ public class RevisionIT extends AbstractDaemonTest {
     input.side = Side.REVISION;
     userRestSession.put(linesUrl, input).assertCreated();
 
-    // admin's own history should be empty (admin didn't mark anything)
+    // admin sees the unified history including user's action
     RestResponse resp = adminRestSession.get(reviewedLineHistoryUrl(r.getChangeId()));
     resp.assertOK();
     List<LineReviewHistoryInfo> history =
         newGson()
             .fromJson(resp.getReader(), new TypeToken<List<LineReviewHistoryInfo>>() {}.getType());
-    assertThat(history).isEmpty();
+    assertThat(history).hasSize(1);
+    assertThat(history.get(0).action).isEqualTo("MARKED");
+    assertThat(history.get(0).line).isEqualTo(7);
+    assertThat(history.get(0).accountId).isEqualTo(user.id().get());
   }
 }

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -3024,6 +3024,7 @@ public class RevisionIT extends AbstractDaemonTest {
 
   @Test
   public void getReviewedLineHistory_empty() throws Exception {
+    // A new change with no mark/unmark actions should return an empty history list.
     PushOneCommit.Result r = createChange();
 
     RestResponse resp = adminRestSession.get(reviewedLineHistoryUrl(r.getChangeId()));
@@ -3036,6 +3037,7 @@ public class RevisionIT extends AbstractDaemonTest {
 
   @Test
   public void getReviewedLineHistory_afterMark() throws Exception {
+    // Marking a line via PUT should produce one MARKED entry with the correct file and line.
     PushOneCommit.Result r = createChange();
     String url = reviewedLinesUrl(r.getChangeId());
 
@@ -3057,6 +3059,7 @@ public class RevisionIT extends AbstractDaemonTest {
 
   @Test
   public void getReviewedLineHistory_afterMarkAndUnmark() throws Exception {
+    // The full mark-then-unmark sequence should be preserved in chronological order.
     PushOneCommit.Result r = createChange();
     String url = reviewedLinesUrl(r.getChangeId());
 
@@ -3079,16 +3082,16 @@ public class RevisionIT extends AbstractDaemonTest {
 
   @Test
   public void getReviewedLineHistory_unifiedAcrossUsers() throws Exception {
+    // History is shared across all users: a different user's mark is visible to admin,
+    // and the response includes the accountId of whoever performed the action.
     PushOneCommit.Result r = createChange();
     String linesUrl = reviewedLinesUrl(r.getChangeId());
 
-    // user marks a line
     LineReviewedInput input = new LineReviewedInput();
     input.line = 7;
     input.side = Side.REVISION;
     userRestSession.put(linesUrl, input).assertCreated();
 
-    // admin sees the unified history including user's action
     RestResponse resp = adminRestSession.get(reviewedLineHistoryUrl(r.getChangeId()));
     resp.assertOK();
     List<LineReviewHistoryInfo> history =

--- a/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
+++ b/javatests/com/google/gerrit/acceptance/api/revision/RevisionIT.java
@@ -56,8 +56,6 @@ import com.google.gerrit.acceptance.testsuite.account.AccountOperations;
 import com.google.gerrit.acceptance.testsuite.change.ChangeOperations;
 import com.google.gerrit.acceptance.testsuite.project.ProjectOperations;
 import com.google.gerrit.acceptance.testsuite.request.RequestScopeOperations;
-import com.google.gerrit.acceptance.testsuite.project.ProjectOperations;
-import com.google.gerrit.acceptance.testsuite.request.RequestScopeOperations;
 import com.google.gerrit.entities.Account;
 import com.google.gerrit.entities.BranchNameKey;
 import com.google.gerrit.entities.BranchOrderSection;
@@ -71,6 +69,7 @@ import com.google.gerrit.entities.RefNames;
 import com.google.gerrit.extensions.api.changes.LineReviewedInput;
 import com.google.gerrit.extensions.client.Side;
 import com.google.gerrit.extensions.common.LineReviewedInfo;
+import com.google.gerrit.extensions.common.LineReviewHistoryInfo;
 import com.google.gson.reflect.TypeToken;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore;
 import com.google.gerrit.extensions.api.changes.ChangeApi;
@@ -3015,5 +3014,86 @@ public class RevisionIT extends AbstractDaemonTest {
             .asString();
 
     assertThat(commitMessage).startsWith("Initial commit message");
+  }
+
+  // -- HTTP-level tests for the reviewed_line_history REST endpoint --
+
+  private String reviewedLineHistoryUrl(String changeId) {
+    return "/changes/" + changeId + "/reviewed_line_history";
+  }
+
+  @Test
+  public void getReviewedLineHistory_empty() throws Exception {
+    PushOneCommit.Result r = createChange();
+
+    RestResponse resp = adminRestSession.get(reviewedLineHistoryUrl(r.getChangeId()));
+    resp.assertOK();
+    List<LineReviewHistoryInfo> history =
+        newGson()
+            .fromJson(resp.getReader(), new TypeToken<List<LineReviewHistoryInfo>>() {}.getType());
+    assertThat(history).isEmpty();
+  }
+
+  @Test
+  public void getReviewedLineHistory_afterMark() throws Exception {
+    PushOneCommit.Result r = createChange();
+    String url = reviewedLinesUrl(r.getChangeId());
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 5;
+    input.side = Side.REVISION;
+    adminRestSession.put(url, input).assertCreated();
+
+    RestResponse resp = adminRestSession.get(reviewedLineHistoryUrl(r.getChangeId()));
+    resp.assertOK();
+    List<LineReviewHistoryInfo> history =
+        newGson()
+            .fromJson(resp.getReader(), new TypeToken<List<LineReviewHistoryInfo>>() {}.getType());
+    assertThat(history).hasSize(1);
+    assertThat(history.get(0).action).isEqualTo("MARKED");
+    assertThat(history.get(0).file).isEqualTo(FILE_NAME);
+    assertThat(history.get(0).line).isEqualTo(5);
+  }
+
+  @Test
+  public void getReviewedLineHistory_afterMarkAndUnmark() throws Exception {
+    PushOneCommit.Result r = createChange();
+    String url = reviewedLinesUrl(r.getChangeId());
+
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 3;
+    input.side = Side.REVISION;
+    adminRestSession.put(url, input).assertCreated();
+    // RestSession.delete() doesn't support a body; use the store directly
+    accountPatchLineReviewStore.clearLineReviewed(r.getPatchSetId(), admin.id(), FILE_NAME, input);
+
+    RestResponse resp = adminRestSession.get(reviewedLineHistoryUrl(r.getChangeId()));
+    resp.assertOK();
+    List<LineReviewHistoryInfo> history =
+        newGson()
+            .fromJson(resp.getReader(), new TypeToken<List<LineReviewHistoryInfo>>() {}.getType());
+    assertThat(history).hasSize(2);
+    assertThat(history.get(0).action).isEqualTo("MARKED");
+    assertThat(history.get(1).action).isEqualTo("UNMARKED");
+  }
+
+  @Test
+  public void getReviewedLineHistory_isolatedByUser() throws Exception {
+    PushOneCommit.Result r = createChange();
+    String linesUrl = reviewedLinesUrl(r.getChangeId());
+
+    // user marks a line
+    LineReviewedInput input = new LineReviewedInput();
+    input.line = 7;
+    input.side = Side.REVISION;
+    userRestSession.put(linesUrl, input).assertCreated();
+
+    // admin's own history should be empty (admin didn't mark anything)
+    RestResponse resp = adminRestSession.get(reviewedLineHistoryUrl(r.getChangeId()));
+    resp.assertOK();
+    List<LineReviewHistoryInfo> history =
+        newGson()
+            .fromJson(resp.getReader(), new TypeToken<List<LineReviewHistoryInfo>>() {}.getType());
+    assertThat(history).isEmpty();
   }
 }

--- a/javatests/com/google/gerrit/acceptance/rest/binding/ChangesRestApiBindingsIT.java
+++ b/javatests/com/google/gerrit/acceptance/rest/binding/ChangesRestApiBindingsIT.java
@@ -87,6 +87,7 @@ public class ChangesRestApiBindingsIT extends AbstractDaemonTest {
           RestCall.post("/changes/%s/reviewers"),
           // GET /changes/<change-id>/revisions is not implemented
           RestCall.builder(GET, "/changes/%s/revisions").expectedResponseCode(SC_NOT_FOUND).build(),
+          RestCall.get("/changes/%s/reviewed_line_history"),
           RestCall.builder(GET, "/changes/%s/robotcomments")
               .expectedResponseCode(SC_NOT_FOUND)
               .build(),

--- a/javatests/com/google/gerrit/server/schema/BUILD
+++ b/javatests/com/google/gerrit/server/schema/BUILD
@@ -1,0 +1,20 @@
+load("//tools/bzl:junit.bzl", "junit_tests")
+
+junit_tests(
+    name = "schema_tests",
+    size = "small",
+    srcs = ["JdbcAccountPatchLineReviewStoreTest.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//java/com/google/gerrit/entities",
+        "//java/com/google/gerrit/extensions:api",
+        "//java/com/google/gerrit/server",
+        "//java/com/google/gerrit/server/schema",
+        "//java/com/google/gerrit/exceptions",
+        "//lib:guava",
+        "//lib:h2",
+        "//lib/commons:dbcp",
+        "//lib/guice",
+        "//lib/truth",
+    ],
+)

--- a/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
+++ b/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
@@ -238,7 +238,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
     var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
 
     ImmutableList<LineReviewHistoryEntry> history =
-        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+        store.findLineReviewHistory(CHANGE_1);
 
     assertThat(history).hasSize(1);
     assertThat(history.get(0).action()).isEqualTo(LineReviewAction.MARKED);
@@ -252,7 +252,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
     store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
 
     ImmutableList<LineReviewHistoryEntry> history =
-        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+        store.findLineReviewHistory(CHANGE_1);
 
     assertThat(history).hasSize(2);
     assertThat(history.get(0).action()).isEqualTo(LineReviewAction.MARKED);
@@ -266,7 +266,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
     var unused2 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(3));
 
     ImmutableList<LineReviewHistoryEntry> history =
-        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+        store.findLineReviewHistory(CHANGE_1);
 
     assertThat(history).hasSize(3);
     assertThat(history.get(0).action()).isEqualTo(LineReviewAction.MARKED);
@@ -275,13 +275,16 @@ public class JdbcAccountPatchLineReviewStoreTest {
   }
 
   @Test
-  public void historyIsolatedByAccount() {
-    var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+  public void historyUnifiedAcrossAccounts() {
+    var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+    var unused2 = store.markLineReviewed(PS_1, ACCOUNT_2, FILE_A, lineInput(2));
 
-    ImmutableList<LineReviewHistoryEntry> historyAccount2 =
-        store.findLineReviewHistory(CHANGE_1, ACCOUNT_2);
+    ImmutableList<LineReviewHistoryEntry> history = store.findLineReviewHistory(CHANGE_1);
 
-    assertThat(historyAccount2).isEmpty();
+    assertThat(history).hasSize(2);
+    assertThat(history.stream().map(LineReviewHistoryEntry::accountId))
+        .containsExactly(ACCOUNT_1, ACCOUNT_2)
+        .inOrder();
   }
 
   @Test
@@ -291,7 +294,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
     store.clearLineReviewed(PS_1);
 
     ImmutableList<LineReviewHistoryEntry> history =
-        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+        store.findLineReviewHistory(CHANGE_1);
 
     assertThat(history).hasSize(1);
     assertThat(history.get(0).action()).isEqualTo(LineReviewAction.MARKED);
@@ -306,7 +309,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
     assertThat(second).isFalse();
 
     ImmutableList<LineReviewHistoryEntry> history =
-        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+        store.findLineReviewHistory(CHANGE_1);
 
     assertThat(history).hasSize(1);
     assertThat(history.get(0).action()).isEqualTo(LineReviewAction.MARKED);
@@ -317,7 +320,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
     store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(99));
 
     ImmutableList<LineReviewHistoryEntry> history =
-        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+        store.findLineReviewHistory(CHANGE_1);
 
     assertThat(history).isEmpty();
   }

--- a/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
+++ b/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
@@ -22,7 +22,10 @@ import com.google.gerrit.entities.PatchSet;
 import com.google.gerrit.extensions.api.changes.LineReviewedInput;
 import com.google.gerrit.extensions.client.Comment.Range;
 import com.google.gerrit.extensions.client.Side;
+import com.google.common.collect.ImmutableList;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.LineReviewAction;
+import com.google.gerrit.server.change.AccountPatchLineReviewStore.LineReviewHistoryEntry;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore.PatchSetWithReviewedLines;
 import com.google.gerrit.server.change.AccountPatchLineReviewStore.ReviewedLine;
 import java.sql.Connection;
@@ -61,6 +64,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
     try (Connection con = store.getConnection();
         Statement stmt = con.createStatement()) {
       stmt.executeUpdate("DROP TABLE IF EXISTS account_patch_line_reviews");
+      stmt.executeUpdate("DROP TABLE IF EXISTS account_patch_line_review_history");
     }
   }
 
@@ -225,5 +229,96 @@ public class JdbcAccountPatchLineReviewStoreTest {
 
     assertThat(store.findReviewedLines(PS_1, ACCOUNT_1, FILE_A)).isEmpty();
     assertThat(store.findReviewedLines(PS_1, ACCOUNT_2, FILE_A)).isPresent();
+  }
+
+  // -- history tests --
+
+  @Test
+  public void markLogsMarkedEntry() {
+    var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+
+    ImmutableList<LineReviewHistoryEntry> history =
+        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+
+    assertThat(history).hasSize(1);
+    assertThat(history.get(0).action()).isEqualTo(LineReviewAction.MARKED);
+    assertThat(history.get(0).path()).isEqualTo(FILE_A);
+    assertThat(history.get(0).lineNumber()).isEqualTo(5);
+  }
+
+  @Test
+  public void clearLogsUnmarkedEntry() {
+    var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+    store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
+
+    ImmutableList<LineReviewHistoryEntry> history =
+        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+
+    assertThat(history).hasSize(2);
+    assertThat(history.get(0).action()).isEqualTo(LineReviewAction.MARKED);
+    assertThat(history.get(1).action()).isEqualTo(LineReviewAction.UNMARKED);
+  }
+
+  @Test
+  public void markUnmarkMark_threeEntriesInOrder() {
+    var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(3));
+    store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(3));
+    var unused2 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(3));
+
+    ImmutableList<LineReviewHistoryEntry> history =
+        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+
+    assertThat(history).hasSize(3);
+    assertThat(history.get(0).action()).isEqualTo(LineReviewAction.MARKED);
+    assertThat(history.get(1).action()).isEqualTo(LineReviewAction.UNMARKED);
+    assertThat(history.get(2).action()).isEqualTo(LineReviewAction.MARKED);
+  }
+
+  @Test
+  public void historyIsolatedByAccount() {
+    var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+
+    ImmutableList<LineReviewHistoryEntry> historyAccount2 =
+        store.findLineReviewHistory(CHANGE_1, ACCOUNT_2);
+
+    assertThat(historyAccount2).isEmpty();
+  }
+
+  @Test
+  public void bulkClear_doesNotLogHistory() {
+    var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
+    // Bulk clear by patch set — should NOT add an UNMARKED history entry
+    store.clearLineReviewed(PS_1);
+
+    ImmutableList<LineReviewHistoryEntry> history =
+        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+
+    assertThat(history).hasSize(1);
+    assertThat(history.get(0).action()).isEqualTo(LineReviewAction.MARKED);
+  }
+
+  @Test
+  public void idempotentMark_doesNotLogDuplicate() {
+    boolean first = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(7));
+    boolean second = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(7));
+
+    assertThat(first).isTrue();
+    assertThat(second).isFalse();
+
+    ImmutableList<LineReviewHistoryEntry> history =
+        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+
+    assertThat(history).hasSize(1);
+    assertThat(history.get(0).action()).isEqualTo(LineReviewAction.MARKED);
+  }
+
+  @Test
+  public void clearNonExistent_doesNotLogHistory() {
+    store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(99));
+
+    ImmutableList<LineReviewHistoryEntry> history =
+        store.findLineReviewHistory(CHANGE_1, ACCOUNT_1);
+
+    assertThat(history).isEmpty();
   }
 }

--- a/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
+++ b/javatests/com/google/gerrit/server/schema/JdbcAccountPatchLineReviewStoreTest.java
@@ -235,6 +235,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
 
   @Test
   public void markLogsMarkedEntry() {
+    // A successful mark should append one MARKED entry to the history.
     var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
 
     ImmutableList<LineReviewHistoryEntry> history =
@@ -248,6 +249,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
 
   @Test
   public void clearLogsUnmarkedEntry() {
+    // Marking then clearing should produce MARKED followed by UNMARKED.
     var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
     store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(5));
 
@@ -261,6 +263,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
 
   @Test
   public void markUnmarkMark_threeEntriesInOrder() {
+    // Each state transition is recorded; re-marking after a clear appends a second MARKED entry.
     var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(3));
     store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(3));
     var unused2 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(3));
@@ -276,6 +279,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
 
   @Test
   public void historyUnifiedAcrossAccounts() {
+    // History is per-change, not per-user: actions from all accounts appear together.
     var unused1 = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
     var unused2 = store.markLineReviewed(PS_1, ACCOUNT_2, FILE_A, lineInput(2));
 
@@ -289,8 +293,8 @@ public class JdbcAccountPatchLineReviewStoreTest {
 
   @Test
   public void bulkClear_doesNotLogHistory() {
+    // Bulk clears (by patch set or change) bypass per-line tracking and don't write history.
     var unused = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(1));
-    // Bulk clear by patch set — should NOT add an UNMARKED history entry
     store.clearLineReviewed(PS_1);
 
     ImmutableList<LineReviewHistoryEntry> history =
@@ -302,6 +306,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
 
   @Test
   public void idempotentMark_doesNotLogDuplicate() {
+    // Marking an already-marked line is a no-op and must not create a duplicate history entry.
     boolean first = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(7));
     boolean second = store.markLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(7));
 
@@ -317,6 +322,7 @@ public class JdbcAccountPatchLineReviewStoreTest {
 
   @Test
   public void clearNonExistent_doesNotLogHistory() {
+    // Clearing a line that was never marked should not write any history entry.
     store.clearLineReviewed(PS_1, ACCOUNT_1, FILE_A, lineInput(99));
 
     ImmutableList<LineReviewHistoryEntry> history =


### PR DESCRIPTION
## Summary
- Fixes #11 
- Add `GET /changes/{id}/reviewed_line_history` REST endpoint returning unified mark/unmark history across all users
- Introduce `LineReviewHistoryEntry` and `LineReviewAction` (MARKED/UNMARKED) in `AccountPatchLineReviewStore`
- Persist history in a new `account_patch_line_review_history` table
- Each history entry includes `accountId`, file, line, side, range, action, and timestamp
- History is per change, not specific to the requesting user

## Test Plan
- [X] Unit tests (`JdbcAccountPatchLineReviewStoreTest`) against in-memory H2
- [X] Acceptance tests over HTTP (`RevisionIT`) verifying response shape, MARKED/UNMARKED sequencing, and unified cross-user visibility
- [X] Route binding tests confirming the new endpoint is registered (`ChangesRestApiBindingsIT`)